### PR TITLE
chore: [IOBP-155] Add ellipses if text too long into `ListItemTransaction`

### DIFF
--- a/src/components/listitems/ListItemTransaction.tsx
+++ b/src/components/listitems/ListItemTransaction.tsx
@@ -115,7 +115,9 @@ export const ListItemTransaction = ({
           </View>
         )}
         <View style={IOStyles.flex}>
-          <H6 color={theme["textBody-default"]}>{title}</H6>
+          <H6 numberOfLines={1} color={theme["textBody-default"]}>
+            {title}
+          </H6>
           <LabelSmall weight="Regular" color={theme["textBody-tertiary"]}>
             {subtitle}
           </LabelSmall>

--- a/src/components/listitems/ListItemTransaction.tsx
+++ b/src/components/listitems/ListItemTransaction.tsx
@@ -17,7 +17,7 @@ import { Badge } from "../badge/Badge";
 import { Icon } from "../icons";
 import { IOLogoPaymentType, LogoPayment } from "../logos";
 import { VSpacer } from "../spacer";
-import { H5, H6, LabelSmall } from "../typography";
+import { H6, LabelSmall } from "../typography";
 import {
   PressableBaseProps,
   PressableListItemBase
@@ -115,9 +115,9 @@ export const ListItemTransaction = ({
           </View>
         )}
         <View style={IOStyles.flex}>
-          <H5 numberOfLines={2} color={theme["textBody-default"]}>
+          <LabelSmall numberOfLines={2} color={theme["textBody-default"]}>
             {title}
-          </H5>
+          </LabelSmall>
           <LabelSmall weight="Regular" color={theme["textBody-tertiary"]}>
             {subtitle}
           </LabelSmall>

--- a/src/components/listitems/ListItemTransaction.tsx
+++ b/src/components/listitems/ListItemTransaction.tsx
@@ -115,7 +115,9 @@ export const ListItemTransaction = ({
           </View>
         )}
         <View style={IOStyles.flex}>
-          <H5 numberOfLines={2}>{title}</H5>
+          <H5 numberOfLines={2} color={theme["textBody-default"]}>
+            {title}
+          </H5>
           <LabelSmall weight="Regular" color={theme["textBody-tertiary"]}>
             {subtitle}
           </LabelSmall>

--- a/src/components/listitems/ListItemTransaction.tsx
+++ b/src/components/listitems/ListItemTransaction.tsx
@@ -17,7 +17,7 @@ import { Badge } from "../badge/Badge";
 import { Icon } from "../icons";
 import { IOLogoPaymentType, LogoPayment } from "../logos";
 import { VSpacer } from "../spacer";
-import { H6, LabelSmall } from "../typography";
+import { H5, H6, LabelSmall } from "../typography";
 import {
   PressableBaseProps,
   PressableListItemBase
@@ -115,9 +115,7 @@ export const ListItemTransaction = ({
           </View>
         )}
         <View style={IOStyles.flex}>
-          <H6 numberOfLines={1} color={theme["textBody-default"]}>
-            {title}
-          </H6>
+          <H5 numberOfLines={2}>{title}</H5>
           <LabelSmall weight="Regular" color={theme["textBody-tertiary"]}>
             {subtitle}
           </LabelSmall>

--- a/src/components/typography/H5.tsx
+++ b/src/components/typography/H5.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { IOColors } from "../../core/IOColors";
+import type { IOColors, IOTheme } from "../../core/IOColors";
 import { FontFamily, IOFontWeight } from "../../utils/fonts";
 import { useTypographyFactory } from "./Factory";
 import { ExternalTypographyProps } from "./common";
@@ -7,7 +7,13 @@ import { ExternalTypographyProps } from "./common";
 // these colors are allowed only when the weight is SemiBold
 type AllowedSemiBoldColors = Extract<
   IOColors,
-  "bluegreyDark" | "bluegrey" | "bluegreyLight" | "blue" | "white" | "red"
+  | IOTheme["textBody-default"]
+  | "bluegreyDark"
+  | "bluegrey"
+  | "bluegreyLight"
+  | "blue"
+  | "white"
+  | "red"
 >;
 
 // when the weight is bold, only the white color is allowed

--- a/src/components/typography/H5.tsx
+++ b/src/components/typography/H5.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { IOColors, IOTheme } from "../../core/IOColors";
+import type { IOColors } from "../../core/IOColors";
 import { FontFamily, IOFontWeight } from "../../utils/fonts";
 import { useTypographyFactory } from "./Factory";
 import { ExternalTypographyProps } from "./common";
@@ -7,13 +7,7 @@ import { ExternalTypographyProps } from "./common";
 // these colors are allowed only when the weight is SemiBold
 type AllowedSemiBoldColors = Extract<
   IOColors,
-  | IOTheme["textBody-default"]
-  | "bluegreyDark"
-  | "bluegrey"
-  | "bluegreyLight"
-  | "blue"
-  | "white"
-  | "red"
+  "bluegreyDark" | "bluegrey" | "bluegreyLight" | "blue" | "white" | "red"
 >;
 
 // when the weight is bold, only the white color is allowed


### PR DESCRIPTION
## Short description
This PR adds ellipsis to `ListItemTransaction` when the title is too long;

## List of changes proposed in this pull request
- Added `numberOfLines={2}` to the title of `ListItemTransaction`;
- Change title typography of `ListItemTransaction` with H5 using 14px;

## How to test
Open the section `ListItem` and check that the ListItemTransaction with a long text has an ellipsis to the and
