### PR TITLE
chore: [IOBP-249] Export `SwitchAction` type

### DIFF
--- a/src/components/listitems/ListItemSwitch.tsx
+++ b/src/components/listitems/ListItemSwitch.tsx
@@ -19,7 +19,7 @@ type Props = {
   action?: SwitchAction;
 };
 
-type SwitchAction = {
+export type SwitchAction = {
   label: string;
   onPress: (event: GestureResponderEvent) => void;
 };


### PR DESCRIPTION
## Short description
This PR exports `SwitchAction` type in order to be used in other scopes and it is useful when creating a dynamic `ListItemSwitch` component into io-app.

## List of changes proposed in this pull request
- Added `export` keyword to `SwitchAction` type.
