### PR TITLE
chore: [IOBP-265] Change max size scale of a Pictogram to `180`

### DIFF
--- a/src/components/pictograms/Pictogram.tsx
+++ b/src/components/pictograms/Pictogram.tsx
@@ -137,7 +137,7 @@ export const IOPictograms = {
 };
 
 export type IOPictograms = keyof typeof IOPictograms;
-export type IOPictogramSizeScale = 48 | 64 | 72 | 80 | 120 | 240;
+export type IOPictogramSizeScale = 48 | 64 | 72 | 80 | 120 | 180;
 
 type IOPictogramsProps = {
   name: IOPictograms;


### PR DESCRIPTION
## Short description
This PR replace the old max Pictogram scale size from value `240` to value `180`

## List of changes proposed in this pull request
- Edited type `IoPictogramSizeScale` into file `Pictogram.tsx` replacing the old value;