### PR TITLE
[IOAPPFD0-156] Delete `IOSpacingScale` array

### DIFF
--- a/src/components/textInput/TextInputBase.tsx
+++ b/src/components/textInput/TextInputBase.tsx
@@ -52,6 +52,8 @@ type InputTextProps = {
   onFocus?: () => void;
 };
 
+const inputMarginTop: IOSpacingScale = 8;
+
 const styles = StyleSheet.create({
   textInput: {
     ...IOStyles.row,
@@ -64,7 +66,7 @@ const styles = StyleSheet.create({
   textInputStyle: {
     ...IOStyles.flex,
     fontSize: 16,
-    marginTop: IOSpacingScale[2],
+    marginTop: inputMarginTop,
     lineHeight: 24,
     height: "100%"
   },

--- a/src/core/IOSpacing.ts
+++ b/src/core/IOSpacing.ts
@@ -4,11 +4,22 @@ Every margin/padding used by different components
 should use a value defined in the following scale.
 */
 
-export const IOSpacingScale = [
-  4, 6, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80
-] as const;
-
-export type IOSpacingScale = (typeof IOSpacingScale)[number];
+export type IOSpacingScale =
+  | 4
+  | 6
+  | 8
+  | 12
+  | 16
+  | 20
+  | 24
+  | 28
+  | 32
+  | 40
+  | 48
+  | 56
+  | 64
+  | 72
+  | 80;
 
 // Values used in the new `<Spacer>` component
 export type IOSpacer = Extract<IOSpacingScale, 4 | 8 | 16 | 24 | 32 | 40 | 48>;


### PR DESCRIPTION
## Short description
This PR removes `IOSpacingScale` because it has been abused by some developers. The relative type `IOSpacingScale` is still present to avoid spacing anarchy in the app.

## List of changes proposed in this pull request
- Remove `IOSpacingScale` array
- Update `TextInputBase` component

## How to test
N/A