### PR TITLE
[IOAPPFD0-157] Refactor `ListItemSwitch` to handle payment logos

### DIFF
--- a/example/src/pages/Selection.tsx
+++ b/example/src/pages/Selection.tsx
@@ -214,24 +214,46 @@ const NativeSwitchShowroom = () => {
 
 type ListItemSwitchSampleProps = Pick<
   React.ComponentProps<typeof ListItemSwitch>,
-  "label" | "description" | "value"
+  "label" | "description" | "value" | "icon" | "paymentLogo"
 >;
 
 const ListItemSwitchSample = ({
   value,
   label,
-  description
+  description,
+  icon,
+  paymentLogo
 }: ListItemSwitchSampleProps) => {
   const [isEnabled, setIsEnabled] = useState(value);
   const toggleSwitch = () => setIsEnabled(previousState => !previousState);
 
   return (
-    <ListItemSwitch
-      label={label}
-      description={description}
-      value={isEnabled}
-      onSwitchValueChange={toggleSwitch}
-    />
+    <>
+      {icon ? (
+        <ListItemSwitch
+          icon={icon}
+          label={label}
+          description={description}
+          value={isEnabled}
+          onSwitchValueChange={toggleSwitch}
+        />
+      ) : paymentLogo ? (
+        <ListItemSwitch
+          paymentLogo={paymentLogo}
+          label={label}
+          description={description}
+          value={isEnabled}
+          onSwitchValueChange={toggleSwitch}
+        />
+      ) : (
+        <ListItemSwitch
+          label={label}
+          description={description}
+          value={isEnabled}
+          onSwitchValueChange={toggleSwitch}
+        />
+      )}
+    </>
   );
 };
 
@@ -255,11 +277,19 @@ const ListItemSwitchShowroom = () => (
       />
       <Divider />
       <ListItemSwitchSample
+        icon="bonus"
         label="Let's try with a loooong loooooong looooooong title + icon"
         description={
           "Ti contatteranno solo i servizi che hanno qualcosa di importante da dirti. Potrai sempre disattivare le comunicazioni che non ti interessano."
         }
       />
+      <Divider />
+      <ListItemSwitchSample
+        paymentLogo="mastercard"
+        label="5354 **** **** 0000"
+      />
+      <Divider />
+      <ListItemSwitchSample paymentLogo="applePay" label="Apple Pay" />
     </ComponentViewerBox>
     <ComponentViewerBox name="ListItemSwitch, disabled">
       <ListItemSwitch disabled label="Testo molto breve" value={true} />
@@ -308,6 +338,15 @@ const ListItemSwitchShowroom = () => (
           variant: "info"
         }}
         description="Inquadra il codice QR mostrato dall’esercente e segui le istruzioni in app per autorizzare la spesa."
+      />
+      <ListItemSwitch
+        icon="coggle"
+        label="Loong loooooong loooooooooong loooong title"
+        value={false}
+        badge={{
+          text: "Attivo",
+          variant: "info"
+        }}
       />
     </ComponentViewerBox>
   </>

--- a/src/components/listitems/ListItemSwitch.tsx
+++ b/src/components/listitems/ListItemSwitch.tsx
@@ -8,7 +8,6 @@ import {
 import {
   IOSelectionListItemStyles,
   IOSelectionListItemVisualParams,
-  IOStyles,
   useIOTheme
 } from "../../core";
 import { IOIcons, Icon } from "../icons";
@@ -16,12 +15,12 @@ import { HSpacer, VSpacer } from "../spacer";
 import { H6, LabelSmall, LabelLink } from "../typography";
 import { NativeSwitch } from "../switch/NativeSwitch";
 import { Badge } from "../badge";
+import { IOLogoPaymentType, LogoPayment } from "../logos";
 
-type Props = {
+type PartialProps = {
   label: string;
   onSwitchValueChange?: (newValue: boolean) => void;
   description?: string;
-  icon?: IOIcons;
   action?: SwitchAction;
   isLoading?: boolean;
   badge?: Badge;
@@ -32,9 +31,19 @@ export type SwitchAction = {
   onPress: (event: GestureResponderEvent) => void;
 };
 
+type ListItemSwitchGraphicProps =
+  | { icon?: never; paymentLogo: IOLogoPaymentType }
+  | { icon: IOIcons; paymentLogo?: never }
+  | { icon?: never; paymentLogo?: never };
+
 const DISABLED_OPACITY = 0.5;
 
-type OwnProps = Props &
+/* Estimated height of the native switch component,
+both on iOS & Android */
+const ESTIMATED_SWITCH_HEIGHT: number = 32;
+
+type ListItemSwitch = PartialProps &
+  ListItemSwitchGraphicProps &
   Pick<React.ComponentProps<typeof Switch>, "value" | "disabled">;
 
 export const ListItemSwitch = React.memo(
@@ -42,13 +51,14 @@ export const ListItemSwitch = React.memo(
     label,
     description,
     icon,
+    paymentLogo,
     value,
     disabled,
     action,
     isLoading,
     badge,
     onSwitchValueChange
-  }: OwnProps) => {
+  }: ListItemSwitch) => {
     const theme = useIOTheme();
 
     return (
@@ -69,70 +79,82 @@ export const ListItemSwitch = React.memo(
             { alignItems: "center" }
           ]}
         >
-          <View style={{ flex: 1 }}>
-            <View style={[IOStyles.row, { flexShrink: 1 }]}>
-              {icon && (
-                <View
-                  style={{
-                    marginRight: IOSelectionListItemVisualParams.iconMargin
-                  }}
-                >
-                  <Icon
-                    name={icon}
-                    color="grey-300"
-                    size={IOSelectionListItemVisualParams.iconSize}
-                  />
-                </View>
-              )}
+          <View
+            style={{
+              flex: 1,
+              flexDirection: "row",
+              alignItems: "center"
+            }}
+          >
+            {icon && (
               <View
                 style={{
-                  flex: 1,
-                  flexDirection: "row",
-                  alignContent: "space-between"
+                  marginRight: IOSelectionListItemVisualParams.iconMargin,
+                  alignSelf: "flex-start"
                 }}
               >
-                <H6 color={"black"} style={{ flex: 1 }}>
-                  {label}
-                </H6>
-                <HSpacer size={8} />
-                <View>
-                  {badge && (
-                    <Badge
-                      text={badge.text}
-                      variant={badge.variant}
-                      testID={badge.testID}
-                    />
-                  )}
-                  {isLoading && <ActivityIndicator color={"black"} />}
-                  {!isLoading && !badge && (
-                    <NativeSwitch
-                      value={value}
-                      onValueChange={onSwitchValueChange}
-                    />
-                  )}
-                </View>
-              </View>
-            </View>
-            {description && (
-              <>
-                <VSpacer
-                  size={IOSelectionListItemVisualParams.descriptionMargin}
+                <Icon
+                  name={icon}
+                  color="grey-300"
+                  size={IOSelectionListItemVisualParams.iconSize}
                 />
-                <LabelSmall weight="Regular" color={theme["textBody-tertiary"]}>
-                  {description}
-                </LabelSmall>
-              </>
+              </View>
             )}
-            {action && (
-              <>
-                <VSpacer size={IOSelectionListItemVisualParams.actionMargin} />
-                <LabelLink fontSize="small" onPress={action.onPress}>
-                  {action.label}
-                </LabelLink>
-              </>
+            {paymentLogo && (
+              <View
+                style={{
+                  marginRight: IOSelectionListItemVisualParams.iconMargin,
+                  alignSelf: "center"
+                }}
+              >
+                <LogoPayment
+                  name={paymentLogo}
+                  size={IOSelectionListItemVisualParams.iconSize}
+                />
+              </View>
+            )}
+
+            <H6 color={"black"} style={{ flex: 1 }}>
+              {label}
+            </H6>
+          </View>
+          <HSpacer size={8} />
+          <View
+            style={{
+              justifyContent: "center",
+              alignSelf: "flex-start",
+              minHeight: ESTIMATED_SWITCH_HEIGHT
+            }}
+          >
+            {badge && (
+              <Badge
+                text={badge.text}
+                variant={badge.variant}
+                testID={badge.testID}
+              />
+            )}
+            {isLoading && <ActivityIndicator color={"black"} />}
+            {!isLoading && !badge && (
+              <NativeSwitch value={value} onValueChange={onSwitchValueChange} />
             )}
           </View>
         </View>
+        {description && (
+          <>
+            <VSpacer size={IOSelectionListItemVisualParams.descriptionMargin} />
+            <LabelSmall weight="Regular" color={theme["textBody-tertiary"]}>
+              {description}
+            </LabelSmall>
+          </>
+        )}
+        {action && (
+          <>
+            <VSpacer size={IOSelectionListItemVisualParams.actionMargin} />
+            <LabelLink fontSize="small" onPress={action.onPress}>
+              {action.label}
+            </LabelLink>
+          </>
+        )}
       </View>
     );
   }


### PR DESCRIPTION
## Short description
This PR refactors the `ListItemSwitch` component to handle payment logos.

## List of changes proposed in this pull request
- Add the new `paymentLogo` prop
- Make the component more robust, avoiding jump between different states (switch → loading indicator → badge)

### Preview
<img src="https://github.com/pagopa/io-app-design-system/assets/1255491/cbb471ba-120a-4aa8-b406-afe49930354c" width="300" />

## How to test
1. Launch the example app
2. Go to the **Selection** page