### PR TITLE
[IOAPPFD0-164] Rename type from `NewRadioItem` to `RadioItem`

### DIFF
--- a/example/src/pages/Selection.tsx
+++ b/example/src/pages/Selection.tsx
@@ -6,7 +6,7 @@ import {
   ListItemCheckbox,
   ListItemSwitch,
   NativeSwitch,
-  NewRadioItem,
+  RadioItem,
   RadioGroup,
   SwitchLabel,
   VSpacer,
@@ -145,7 +145,7 @@ const renderListItemCheckbox = () => (
 
 // RADIO ITEMS
 
-const mockRadioItems = (): ReadonlyArray<NewRadioItem<string>> => [
+const mockRadioItems = (): ReadonlyArray<RadioItem<string>> => [
   {
     icon: "coggle",
     value: "Let's try with a basic title",

--- a/src/components/radio/RadioGroup.tsx
+++ b/src/components/radio/RadioGroup.tsx
@@ -4,7 +4,7 @@ import { Divider } from "../divider";
 import { IOIcons } from "../icons";
 import { ListItemRadio } from "../listitems/ListItemRadio";
 
-export type NewRadioItem<T> = {
+export type RadioItem<T> = {
   id: T;
   value: string;
   description?: string;
@@ -13,7 +13,7 @@ export type NewRadioItem<T> = {
 };
 
 type Props<T> = {
-  items: ReadonlyArray<NewRadioItem<T>>;
+  items: ReadonlyArray<RadioItem<T>>;
   selectedItem?: T;
   onPress: (selected: T) => void;
 };


### PR DESCRIPTION
## Short description
This PR does exactly what the title says.

## List of changes proposed in this pull request
- Rename type from `NewRadioItem` to `RadioItem`

## How to test
N/A