### PR TITLE
[IABT-1490] Fix amount text a11y in `ListItemTransaction`

### DIFF
--- a/src/components/listitems/ListItemTransaction.tsx
+++ b/src/components/listitems/ListItemTransaction.tsx
@@ -64,6 +64,7 @@ export type ListItemTransaction = WithTestID<
     paymentLogoIcon?: ListItemTransactionLogo;
     subtitle: string;
     title: string;
+    accessible?: boolean;
   } & (
       | {
           transactionStatus: ListItemTransactionStatusWithoutBadge;
@@ -114,7 +115,8 @@ export const ListItemTransaction = ({
   title,
   transactionAmount,
   badgeText,
-  transactionStatus = "success"
+  transactionStatus = "success",
+  accessible
 }: ListItemTransaction) => {
   const theme = useIOTheme();
 
@@ -203,7 +205,7 @@ export const ListItemTransaction = ({
         <View
           style={IOListItemStyles.listItem}
           testID={testID}
-          accessible={false}
+          accessible={accessible}
           accessibilityLabel={accessibilityLabel}
         >
           <View style={IOListItemStyles.listItemInner}>

--- a/src/components/listitems/ListItemTransaction.tsx
+++ b/src/components/listitems/ListItemTransaction.tsx
@@ -14,12 +14,12 @@ import {
   useIOTheme
 } from "../../core";
 
-import { LogoPaymentWithFallback } from "../common/LogoPaymentWithFallback";
-import { isImageUri } from "../../utils/url";
-import { WithTestID } from "../../utils/types";
 import { getAccessibleAmountText } from "../../utils/accessibility";
+import { WithTestID } from "../../utils/types";
+import { isImageUri } from "../../utils/url";
 import { Avatar } from "../avatar/Avatar";
 import { Badge } from "../badge/Badge";
+import { LogoPaymentWithFallback } from "../common/LogoPaymentWithFallback";
 import { IOIconSizeScale, Icon } from "../icons";
 import { IOLogoPaymentType } from "../logos";
 import { VSpacer } from "../spacer";
@@ -203,7 +203,7 @@ export const ListItemTransaction = ({
         <View
           style={IOListItemStyles.listItem}
           testID={testID}
-          accessible={true}
+          accessible={false}
           accessibilityLabel={accessibilityLabel}
         >
           <View style={IOListItemStyles.listItemInner}>


### PR DESCRIPTION
## Short description
This PR fixes an accessibility issue with the `ListItemTransaction` where, on iOS, VoiceOver reads time and amount numbers as one number (eg: `23:15 45,67€` reads "23" and "1.545,67€").

The fix consists in setting to `false` the `accessible` prop in the parent component. Now the `accessible` prop is passed from the parent component, default is `false`.

## List of changes proposed in this pull request
- [src/components/listitems/ListItemTransaction.tsx](https://github.com/pagopa/io-app-design-system/pull/91/files#diff-e161c812707e7a718a116a2c9a28e50d9d46a9956ffa18d7950aafe270570ed9): added the `accessible` prop in the parent component.

## How to test
Use VoiceOver on iOS to read an `ListItemTransaction` component.
This issue should be tests on physical devices since it cannot be reproduced on simulators.
