### PR TITLE
chore: add `autoCapitalize` to `RNTextInputProps`

### DIFF
--- a/example/src/pages/TextInputs.tsx
+++ b/example/src/pages/TextInputs.tsx
@@ -1,15 +1,15 @@
-import * as React from "react";
-import { View } from "react-native";
 import {
-  IOVisualCostants,
+  H4,
+  H5,
   IOStyles,
-  VSpacer,
+  IOVisualCostants,
   TextInput,
   TextInputPassword,
   TextInputValidation,
-  H4,
-  H5
+  VSpacer
 } from "@pagopa/io-app-design-system";
+import * as React from "react";
+import { View } from "react-native";
 import { Screen } from "../components/Screen";
 
 const InputComponentWrapper = (
@@ -84,7 +84,7 @@ export const TextInputs = () => (
       <H5>Base input with value formatted</H5>
       <InputComponentWrapper
         placeholder={"Base input"}
-        inputTyoe={"credit-card"}
+        inputType={"credit-card"}
         bottomMessage="Handles credit card input type"
       />
       <H5>Base input with validation</H5>

--- a/src/components/textInput/TextInputBase.tsx
+++ b/src/components/textInput/TextInputBase.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable functional/immutable-data */
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   Pressable,
   StyleSheet,
@@ -6,7 +7,6 @@ import {
   View,
   ViewStyle
 } from "react-native";
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import Animated, {
   Easing,
   useAnimatedStyle,
@@ -19,12 +19,12 @@ import {
   IOStyles,
   useIOExperimentalDesign
 } from "../../core";
+import { makeFontStyleObject } from "../../utils/fonts";
+import { getInputPropsByType } from "../../utils/textInput";
+import { InputType } from "../../utils/types";
 import { IOIcons, Icon } from "../icons";
 import { HSpacer } from "../spacer";
 import { LabelSmall } from "../typography";
-import { InputType } from "../../utils/types";
-import { getInputPropsByType } from "../../utils/textInput";
-import { makeFontStyleObject } from "../../utils/fonts";
 
 type InputStatus = "initial" | "focused" | "disabled" | "error";
 
@@ -35,6 +35,7 @@ type RNTextInputProps = Pick<
   | "textContentType"
   | "autoComplete"
   | "returnKeyType"
+  | "autoCapitalize"
 >;
 
 type InputTextProps = {


### PR DESCRIPTION
## Short description
This PR adds the ability to pass `autoCapitalize` prop to `TextInput` component

## List of changes proposed in this pull request
- Added `autoCapitalize` to `RNTextInputProps` type

## How to test
Use a TextInput component and pass `autoCapitalize` to the `textInputProps`. Check that the casing is correctly handled by the component.
