### PR TITLE
chore: add `autoCorrect` prop to `TextInput` component

### DIFF
--- a/src/components/textInput/TextInputBase.tsx
+++ b/src/components/textInput/TextInputBase.tsx
@@ -36,6 +36,7 @@ type RNTextInputProps = Pick<
   | "autoComplete"
   | "returnKeyType"
   | "autoCapitalize"
+  | "autoCorrect"
 >;
 
 type InputTextProps = {


### PR DESCRIPTION
## Short description
This PR adds the `autoCorrect` prop to `TextInput` component

## List of changes proposed in this pull request
- [src/components/textInput/TextInputBase.tsx](https://github.com/pagopa/io-app-design-system/compare/add-auto-correct-prop-to-text-input?expand=1#diff-4c896698eb784ea23eeccb310d573873e1d296d505cf84c166d59f61be6e3968): added `autoCorrect` in the Pick type

## How to test
On a `TextInput` component, try to pass the `autoCorrect` prop in the `textInputProps` and check if the component has the expected behavior.
