### PR TITLE
fix: HeaderSecondLevel background color don't covers safearea

### DIFF
--- a/example/src/pages/HeaderSecondLevel.tsx
+++ b/example/src/pages/HeaderSecondLevel.tsx
@@ -11,6 +11,7 @@ import {
   Body,
   H3,
   HeaderSecondLevel,
+  IOColors,
   IOVisualCostants,
   VSpacer
 } from "@pagopa/io-app-design-system";
@@ -39,6 +40,7 @@ export const HeaderSecondLevelScreen = () => {
 
   React.useLayoutEffect(() => {
     navigation.setOptions({
+      headerTransparent: true,
       header: () => (
         <HeaderSecondLevel
           scrollValues={{
@@ -79,6 +81,7 @@ export const HeaderSecondLevelScreen = () => {
   return (
     <Animated.ScrollView
       contentContainerStyle={{
+        marginTop: insets.top + IOVisualCostants.headerHeight,
         paddingBottom: insets.bottom,
         paddingHorizontal: IOVisualCostants.appMarginDefault
       }}
@@ -88,7 +91,10 @@ export const HeaderSecondLevelScreen = () => {
       snapToEnd={false}
       decelerationRate="normal"
     >
-      <View onLayout={getTitleHeight}>
+      <View
+        onLayout={getTitleHeight}
+        // style={{ backgroundColor: IOColors["hanPurple-500"] }}
+      >
         <H3>Questo è un titolo lungo, ma lungo lungo davvero, eh!</H3>
       </View>
       <VSpacer />

--- a/example/src/pages/HeaderSecondLevel.tsx
+++ b/example/src/pages/HeaderSecondLevel.tsx
@@ -11,7 +11,6 @@ import {
   Body,
   H3,
   HeaderSecondLevel,
-  IOColors,
   IOVisualCostants,
   VSpacer
 } from "@pagopa/io-app-design-system";

--- a/example/src/pages/HeaderSecondLevel.tsx
+++ b/example/src/pages/HeaderSecondLevel.tsx
@@ -48,6 +48,7 @@ export const HeaderSecondLevelScreen = () => {
           title={"Questo è un titolo lungo, ma lungo lungo davvero, eh!"}
           goBack={() => navigation.goBack()}
           backAccessibilityLabel="Torna indietro"
+          transparent={true}
           type="threeActions"
           firstAction={{
             icon: "help",

--- a/src/components/layout/HeaderSecondLevel.tsx
+++ b/src/components/layout/HeaderSecondLevel.tsx
@@ -144,21 +144,18 @@ export const HeaderSecondLevel = ({
   }));
 
   return (
-    <Animated.View
+    <View
       accessibilityRole="header"
-      style={
+      style={[
+        { paddingTop: insets.top },
         transparent
           ? { borderBottomWidth: 0 }
           : { backgroundColor: IOColors[HEADER_BG_COLOR] }
-      }
+      ]}
     >
       <Animated.View
         testID={testID}
-        style={[
-          { marginTop: insets.top },
-          styles.headerInner,
-          headerWrapperAnimatedStyle
-        ]}
+        style={[styles.headerInner, headerWrapperAnimatedStyle]}
       >
         <IconButton
           icon={Platform.OS === "ios" ? "backiOS" : "backAndroid"}
@@ -201,7 +198,7 @@ export const HeaderSecondLevel = ({
           )}
         </View>
       </Animated.View>
-    </Animated.View>
+    </View>
   );
 };
 

--- a/src/components/layout/HeaderSecondLevel.tsx
+++ b/src/components/layout/HeaderSecondLevel.tsx
@@ -74,7 +74,6 @@ const styles = StyleSheet.create({
   headerInner: {
     paddingHorizontal: IOVisualCostants.appMarginDefault,
     height: IOVisualCostants.headerHeight,
-    borderBottomWidth: 1,
     flexGrow: 1,
     flexDirection: "row",
     alignItems: "center",
@@ -144,18 +143,19 @@ export const HeaderSecondLevel = ({
   }));
 
   return (
-    <View
+    <Animated.View
       accessibilityRole="header"
       style={[
-        { paddingTop: insets.top },
         transparent
           ? { borderBottomWidth: 0 }
-          : { backgroundColor: IOColors[HEADER_BG_COLOR] }
+          : { backgroundColor: IOColors[HEADER_BG_COLOR] },
+        { borderBottomWidth: 1 },
+        headerWrapperAnimatedStyle
       ]}
     >
       <Animated.View
         testID={testID}
-        style={[styles.headerInner, headerWrapperAnimatedStyle]}
+        style={[{ marginTop: insets.top }, styles.headerInner]}
       >
         <IconButton
           icon={Platform.OS === "ios" ? "backiOS" : "backAndroid"}
@@ -198,7 +198,7 @@ export const HeaderSecondLevel = ({
           )}
         </View>
       </Animated.View>
-    </View>
+    </Animated.View>
   );
 };
 


### PR DESCRIPTION
## Short description
Fixes the header background color when transparent mode is enabled

## List of changes proposed in this pull request
- Feature A

## How to test
Check the HeaderSecondLevel page on example app add a background color to any element, header should cover it.
