### PR TITLE
fix: Restore TextInput tap events on Label area

### DIFF
--- a/src/components/textInput/TextInputBase.tsx
+++ b/src/components/textInput/TextInputBase.tsx
@@ -317,6 +317,7 @@ export const TextInputBase = ({
          * translate to top on focus
          */}
         <Animated.View
+          pointerEvents={"none"}
           style={[styles.textInputLabelWrapper, icon ? { left: 32 } : {}]}
         >
           <Animated.Text


### PR DESCRIPTION
## Short description
This PR fixes an issue on TextInput component preventing tap on the Label area

## List of changes proposed in this pull request
- Fixes TextInput components

## How to test
Check Example app related page