### PR TITLE
Add `contrast` variant to `ButtonLink`

### DIFF
--- a/example/src/pages/Buttons.tsx
+++ b/example/src/pages/Buttons.tsx
@@ -515,6 +515,84 @@ export const Buttons = () => {
         </View>
       </ComponentViewerBox>
 
+      <View
+        style={isExperimental ? styles.primaryBlock : styles.primaryBlockLegacy}
+      >
+        <ComponentViewerBox
+          name="ButtonLink · Contrast variant"
+          colorMode="dark"
+        >
+          <View>
+            <ButtonLink
+              color="contrast"
+              accessibilityLabel="Tap to trigger test alert"
+              label={"Primary button"}
+              onPress={onButtonPress}
+            />
+
+            <VSpacer size={16} />
+
+            <ButtonLink
+              color="contrast"
+              accessibilityLabel="Tap to trigger test alert"
+              label={"Primary button"}
+              icon="starEmpty"
+              onPress={onButtonPress}
+            />
+
+            <VSpacer size={16} />
+
+            <ButtonLink
+              color="contrast"
+              accessibilityLabel="Tap to trigger test alert"
+              label={"Primary button"}
+              icon="starEmpty"
+              iconPosition="end"
+              onPress={onButtonPress}
+            />
+
+            <VSpacer size={16} />
+
+            <View style={{ alignSelf: "center" }}>
+              <ButtonLink
+                color="contrast"
+                accessibilityLabel="Tap to trigger test alert"
+                label={"Primary button (centered)"}
+                onPress={onButtonPress}
+              />
+            </View>
+          </View>
+        </ComponentViewerBox>
+
+        <ComponentViewerBox
+          name="ButtonLink · Contrast, disabled"
+          colorMode="dark"
+          last
+        >
+          <View>
+            <ButtonLink
+              disabled
+              color="contrast"
+              accessibilityLabel="Tap to trigger test alert"
+              label={"Primary button (disabled)"}
+              onPress={onButtonPress}
+            />
+
+            <VSpacer size={16} />
+
+            <ButtonLink
+              disabled
+              color="contrast"
+              accessibilityLabel="Tap to trigger test alert"
+              label={"Primary button (disabled)"}
+              icon="starEmpty"
+              iconPosition="end"
+              onPress={onButtonPress}
+            />
+          </View>
+        </ComponentViewerBox>
+      </View>
+
       <VSpacer size={40} />
 
       <H2

--- a/src/components/buttons/ButtonLink.tsx
+++ b/src/components/buttons/ButtonLink.tsx
@@ -15,6 +15,7 @@ import {
   IOColors,
   IOScaleValues,
   IOSpringValues,
+  hexToRgba,
   useIOExperimentalDesign
 } from "../../core";
 import { makeFontStyleObject } from "../../utils/fonts";
@@ -28,7 +29,8 @@ import {
 import { HSpacer } from "../spacer/Spacer";
 import { buttonTextFontSize } from "../typography";
 
-export type ColorButtonLink = "primary";
+export type ColorButtonLink = "primary" | "contrast";
+
 export type ButtonLinkProps = WithTestID<{
   color?: ColorButtonLink;
   label: string;
@@ -62,6 +64,13 @@ const mapColorStates: Record<
       pressed: IOColors["blueIO-600"],
       disabled: IOColors["grey-700"]
     }
+  },
+  contrast: {
+    label: {
+      default: IOColors.white,
+      pressed: hexToRgba(IOColors.white, 0.85),
+      disabled: hexToRgba(IOColors.white, 0.5)
+    }
   }
 };
 
@@ -76,6 +85,13 @@ const mapLegacyColorStates: Record<
       default: IOColors.blue,
       pressed: IOColors["blue-600"],
       disabled: IOColors["grey-700"]
+    }
+  },
+  contrast: {
+    label: {
+      default: IOColors.white,
+      pressed: hexToRgba(IOColors.white, 0.85),
+      disabled: hexToRgba(IOColors.white, 0.5)
     }
   }
 };


### PR DESCRIPTION
## Short description
This PR adds the `contrast` variant to the `ButtonLink` component

## List of changes proposed in this pull request
- Add the missing `contrast` variant

### Preview
<img src="https://github.com/pagopa/io-app-design-system/assets/1255491/923b0223-ee51-4cf8-b888-f15b431b067e" width="360" />

## How to test
1. Launch the example app
2. Go to the **Buttons** page