### PR TITLE
[IOAPPFD0-195] `HeaderFirstLevel` · Change `IconButton` color to `primary` (from `neutral`)

### DIFF
--- a/example/src/pages/HeaderFirstLevel.tsx
+++ b/example/src/pages/HeaderFirstLevel.tsx
@@ -19,7 +19,7 @@ export const HeaderFirstLevelScreen = () => {
     navigation.setOptions({
       header: () => (
         <HeaderFirstLevel
-          backgroundColor="dark"
+          backgroundColor="light"
           title={"Pagina"}
           type="singleAction"
           firstAction={{

--- a/src/components/layout/HeaderFirstLevel.tsx
+++ b/src/components/layout/HeaderFirstLevel.tsx
@@ -94,7 +94,7 @@ export const HeaderFirstLevel = ({
             <>
               <IconButton
                 {...thirdAction}
-                color={backgroundColor === "dark" ? "contrast" : "neutral"}
+                color={backgroundColor === "dark" ? "contrast" : "primary"}
               />
               {/* Ideally, with the "gap" flex property,
               we can get rid of these ugly constructs */}
@@ -105,7 +105,7 @@ export const HeaderFirstLevel = ({
             <>
               <IconButton
                 {...secondAction}
-                color={backgroundColor === "dark" ? "contrast" : "neutral"}
+                color={backgroundColor === "dark" ? "contrast" : "primary"}
               />
               {/* Same as above */}
               <HSpacer size={16} />
@@ -114,7 +114,7 @@ export const HeaderFirstLevel = ({
           {type !== "base" && (
             <IconButton
               {...firstAction}
-              color={backgroundColor === "dark" ? "contrast" : "neutral"}
+              color={backgroundColor === "dark" ? "contrast" : "primary"}
             />
           )}
         </View>

--- a/src/components/layout/HeaderFirstLevel.tsx
+++ b/src/components/layout/HeaderFirstLevel.tsx
@@ -85,7 +85,7 @@ export const HeaderFirstLevel = ({
         <H3
           style={{ flexShrink: 1 }}
           numberOfLines={1}
-          color={backgroundColor === "dark" ? "white" : undefined}
+          color={backgroundColor === "dark" ? "white" : "black"}
         >
           {title}
         </H3>


### PR DESCRIPTION
## Short description
This PR changes `IconButton` color to `primary` in the `HeaderFirstLevel` component.

## List of changes proposed in this pull request
- As described in the short description
- Force title to be black (was `undefined`) in the light variant

### Preview
| Before | After |
|--------|--------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-11-28 at 14 13 18](https://github.com/pagopa/io-app-design-system/assets/1255491/6471bc9b-0cb6-49a7-a270-c8ea51207a32) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-11-28 at 14 12 28](https://github.com/pagopa/io-app-design-system/assets/1255491/c9828bf9-ca15-4319-ae6f-427ad59b96fb) | 


## How to test
1. Launch the example app
2. Go to the **Header First Level** screen