### PR TITLE
[IOAPPFD0-203] Fix the margin of the icon of the `ListItemHeader` component that is too wide

### DIFF
--- a/src/components/listitems/ListItemHeader.tsx
+++ b/src/components/listitems/ListItemHeader.tsx
@@ -3,14 +3,15 @@ import { View } from "react-native";
 import {
   IOListItemStyles,
   IOListItemVisualParams,
+  IOSpacingScale,
   IOStyles,
   useIOTheme
 } from "../../core";
 import { WithTestID } from "../../utils/types";
+import { Badge } from "../badge";
+import { ButtonLink, IconButton } from "../buttons";
 import { IOIcons, Icon } from "../icons";
 import { H6 } from "../typography";
-import { ButtonLink, IconButton } from "../buttons";
-import { Badge } from "../badge";
 
 type ButtonLinkActionProps = {
   type: "buttonLink";
@@ -47,6 +48,8 @@ export type ListItemHeader = WithTestID<{
   accessibilityLabel?: string;
 }> &
   IconProps;
+
+const iconMargin: IOSpacingScale = 8;
 
 export const ListItemHeader = ({
   label,
@@ -124,7 +127,7 @@ export const ListItemHeader = ({
     >
       <View style={IOListItemStyles.listItemInner}>
         {iconName && (
-          <View style={{ marginRight: IOListItemVisualParams.actionMargin }}>
+          <View style={{ marginRight: iconMargin }}>
             <Icon
               name={iconName}
               color={iconColor ?? theme["icon-decorative"]}


### PR DESCRIPTION
## Short description
This PR fixes the margin of the icon of the `ListItemHeader` component that is too wide.

### Preview
| Before | After |
|--------|--------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-12-15 at 15 01 14](https://github.com/pagopa/io-app-design-system/assets/1255491/082e395c-e9d3-4bcf-ba82-18d810925fa4) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-12-15 at 15 23 20](https://github.com/pagopa/io-app-design-system/assets/1255491/4cf373b0-db28-46cb-958a-72e8b358fcbd) | 

## How to test
1. Launch the example app
2. Go to the **List Items** page