### PR TITLE
[IOAPPFD0-204] Fix wrong color of `ListItemRadioWithAmount` label when new DS is turned off

### DIFF
--- a/src/components/listitems/ListItemRadioWithAmount.tsx
+++ b/src/components/listitems/ListItemRadioWithAmount.tsx
@@ -34,7 +34,7 @@ export const ListItemRadioWithAmount = (
       props.onValueChange(!toggleValue);
     }
   };
-  const isExperimental = useIOExperimentalDesign();
+  const { isExperimental } = useIOExperimentalDesign();
 
   const interactiveColor: IOColors = isExperimental ? "blueIO-500" : "blue";
   const suggestColor: IOColors = "hanPurple-500";

--- a/src/components/listitems/__test__/__snapshots__/listitem.test.tsx.snap
+++ b/src/components/listitems/__test__/__snapshots__/listitem.test.tsx.snap
@@ -2842,7 +2842,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 1`] = `
       >
         <Text
           allowFontScaling={false}
-          color="blueIO-500"
+          color="blue"
           defaultColor="black"
           defaultWeight="SemiBold"
           font="TitilliumWeb"
@@ -2859,7 +2859,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 1`] = `
                 "lineHeight": 25,
               },
               {
-                "color": "#0B3EE3",
+                "color": "#0073E6",
                 "fontFamily": "Titillium Web",
                 "fontStyle": "normal",
                 "fontWeight": "600",
@@ -3122,7 +3122,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 2`] = `
       >
         <Text
           allowFontScaling={false}
-          color="blueIO-500"
+          color="blue"
           defaultColor="black"
           defaultWeight="SemiBold"
           font="TitilliumWeb"
@@ -3139,7 +3139,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 2`] = `
                 "lineHeight": 25,
               },
               {
-                "color": "#0B3EE3",
+                "color": "#0073E6",
                 "fontFamily": "Titillium Web",
                 "fontStyle": "normal",
                 "fontWeight": "600",


### PR DESCRIPTION
## Short description
This PR fixes the wrong color of `ListItemRadioWithAmount` label, caused by the incorrect declaration of the `useIOExperimentalDesign` hook

## List of changes proposed in this pull request
- Fix the declaration using the object destructuring syntax, from `const isExperimental` to `const { isExperimental }`

## How to test
1. Launch the example app
2. Go to the **Selection** page and look for `ListItemRadioWithAmount` (under **Radio** group)