### PR TITLE
[IACROSS-214] Increase the font size of the `FeatureInfo` component

### DIFF
--- a/src/components/featureInfo/FeatureInfo.tsx
+++ b/src/components/featureInfo/FeatureInfo.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { GestureResponderEvent, View } from "react-native";
-import { IOStyles } from "../../core";
 import {
+  Body,
   HSpacer,
   IOIconSizeScale,
   IOIcons,
@@ -9,10 +9,10 @@ import {
   IOPictograms,
   Icon,
   LabelLink,
-  LabelSmall,
   Pictogram,
   VSpacer
 } from "../../components";
+import { IOStyles } from "../../core";
 
 type PartialFeatureInfo = {
   // Necessary to render main body with different formatting
@@ -43,9 +43,9 @@ const DEFAULT_PICTOGRAM_SIZE: IOPictogramSizeScale = 48;
 const renderNode = (body: FeatureInfoProps["body"]) => {
   if (typeof body === "string") {
     return (
-      <LabelSmall weight="Regular" color="grey-700" testID="infoScreenBody">
+      <Body color="grey-700" testID="infoScreenBody">
         {body}
-      </LabelSmall>
+      </Body>
     );
   }
 
@@ -74,8 +74,8 @@ export const FeatureInfo = ({
           {/* Add "marginTop" equivalent if body text is present.
           This verbose code could be deleted once we got "gap"
           property support */}
-          {body && <VSpacer size={8} />}
-          <LabelLink fontSize="small" onPress={actionOnPress}>
+          {body && <VSpacer size={4} />}
+          <LabelLink fontSize="regular" onPress={actionOnPress}>
             {actionLabel}
           </LabelLink>
         </>


### PR DESCRIPTION
## Short description
This PR increases the font size in the `FeatureInfo` component.

## List of changes proposed in this pull request
- Change typographic styles (from default `14` font size to `16`)

### Preview
| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 14 Pro - 2024-01-22 at 15 16 39](https://github.com/pagopa/io-app-design-system/assets/1255491/e3fe32d7-2cd4-46b9-b10b-f3ae1b0849ab) | ![Simulator Screenshot - iPhone 14 Pro - 2024-01-22 at 15 16 05](https://github.com/pagopa/io-app-design-system/assets/1255491/a7a23ebc-93f9-4f1b-8c6d-02c67ac9fdd2) | 

## How to test
1. Run the example app
2. Go to the **Advice & Banners** page