### PR TITLE
[chore] Accessibility of empty Header Second Level's title

### DIFF
--- a/src/components/layout/HeaderSecondLevel.tsx
+++ b/src/components/layout/HeaderSecondLevel.tsx
@@ -143,6 +143,7 @@ export const HeaderSecondLevel = ({
       : "transparent"
   }));
 
+  const isTitleAccessible = !!title.trim();
   const titleAnimatedStyle = useAnimatedStyle(() => ({
     opacity: scrollValues
       ? interpolate(
@@ -183,6 +184,7 @@ export const HeaderSecondLevel = ({
         )}
         <Animated.Text
           numberOfLines={1}
+          accessible={isTitleAccessible}
           style={[
             styles.headerTitle,
             isExperimental


### PR DESCRIPTION
## Short description
This PR disables accessibility on the title of the HeaderSecondLevel when the former is an trimmed empty string.

## List of changes proposed in this pull request
- Title's accessibility is disabled if the trimmed string is empty

