### PR TITLE
[chore] ButtonSolid and ButtonOutline accessibility on Android

### DIFF
--- a/src/components/buttons/ButtonOutline.tsx
+++ b/src/components/buttons/ButtonOutline.tsx
@@ -383,6 +383,7 @@ export const ButtonOutline = ({
           ellipsizeMode="tail"
           allowFontScaling={isExperimental}
           maxFontSizeMultiplier={1.3}
+          importantForAccessibility="no-hide-descendants"
         >
           {label}
         </Animated.Text>

--- a/src/components/buttons/ButtonSolid.tsx
+++ b/src/components/buttons/ButtonSolid.tsx
@@ -320,6 +320,7 @@ export const ButtonSolid = React.memo(
                 ellipsizeMode="tail"
                 allowFontScaling={isExperimental}
                 maxFontSizeMultiplier={1.3}
+                importantForAccessibility="no-hide-descendants"
               >
                 {label}
               </ButtonText>

--- a/src/components/buttons/__test__/__snapshots__/button.test.tsx.snap
+++ b/src/components/buttons/__test__/__snapshots__/button.test.tsx.snap
@@ -338,6 +338,7 @@ exports[`Test Buttons Components - Experimental Enabled ButtonOutline Snapshot 1
     <Text
       allowFontScaling={true}
       ellipsizeMode="tail"
+      importantForAccessibility="no-hide-descendants"
       maxFontSizeMultiplier={1.3}
       numberOfLines={1}
       style={
@@ -463,6 +464,7 @@ exports[`Test Buttons Components - Experimental Enabled ButtonSolid Snapshot 1`]
             "fontSize": 16,
           }
         }
+        importantForAccessibility="no-hide-descendants"
         maxFontSizeMultiplier={1.3}
         numberOfLines={1}
         style={
@@ -1199,6 +1201,7 @@ exports[`Test Buttons Components ButtonOutline Snapshot 1`] = `
     <Text
       allowFontScaling={false}
       ellipsizeMode="tail"
+      importantForAccessibility="no-hide-descendants"
       maxFontSizeMultiplier={1.3}
       numberOfLines={1}
       style={
@@ -1323,6 +1326,7 @@ exports[`Test Buttons Components ButtonSolid Snapshot 1`] = `
             "fontSize": 16,
           }
         }
+        importantForAccessibility="no-hide-descendants"
         maxFontSizeMultiplier={1.3}
         numberOfLines={1}
         style={


### PR DESCRIPTION
## Short description
This PR improves the accessibility behaviour on ButtonSolid and ButtonOutline on Android devices.

## List of changes proposed in this pull request
- On Android, TalkBack was reading a button's label twice. Its text part has been configured to be ignored.
- iOS already has the right behaviour, since it works by reading the `accessibility={true}` flag on the parent item and groups all its children together.
