### PR TITLE
chore: Set the `ModuleCheckout` description prop as optional

### DIFF
--- a/example/src/pages/Modules.tsx
+++ b/example/src/pages/Modules.tsx
@@ -115,6 +115,14 @@ const renderModuleCheckout = () => (
         onPress={modulePress}
       />
     </ComponentViewerBox>
+    <ComponentViewerBox name="ModuleCheckout, no description">
+      <ModuleCheckout
+        paymentLogo="amex"
+        title="Amex"
+        ctaText="Modifica"
+        onPress={modulePress}
+      />
+    </ComponentViewerBox>
     <ComponentViewerBox name="ModuleCheckout, no icon">
       <ModuleCheckout
         title="3,50 $"

--- a/src/components/modules/ModuleCheckout.tsx
+++ b/src/components/modules/ModuleCheckout.tsx
@@ -20,7 +20,7 @@ type ModuleCheckoutPartialProps =
       isLoading?: false;
       paymentLogo?: IOLogoPaymentType;
       title: string;
-      subtitle: string;
+      subtitle?: string;
       onPress: () => void;
     }
   | {
@@ -62,9 +62,11 @@ export const ModuleCheckout = (props: ModuleCheckoutProps) => {
       )}
       <View style={IOStyles.flex}>
         <H6>{props.title}</H6>
-        <LabelSmall weight="Regular" color={theme["textBody-tertiary"]}>
-          {props.subtitle}
-        </LabelSmall>
+        {props.subtitle && (
+          <LabelSmall weight="Regular" color={theme["textBody-tertiary"]}>
+            {props.subtitle}
+          </LabelSmall>
+        )}
       </View>
     </View>
   );


### PR DESCRIPTION
## Short description
This PR makes the `ModuleCheckout` description prop as an optional property

## List of changes proposed in this pull request
- Changed `description` property to optional 

