### PR TITLE
[IOPID-1610] on RadioGroup component change type of description

### DIFF
--- a/example/src/pages/Selection.tsx
+++ b/example/src/pages/Selection.tsx
@@ -2,7 +2,9 @@ import {
   CheckboxLabel,
   Divider,
   H2,
+  IOColors,
   IOVisualCostants,
+  LabelSmall,
   ListItemCheckbox,
   ListItemSwitch,
   NativeSwitch,
@@ -15,7 +17,7 @@ import {
   useIOExperimentalDesign
 } from "@pagopa/io-app-design-system";
 import React, { useState } from "react";
-import { View } from "react-native";
+import { Text, View } from "react-native";
 import { ComponentViewerBox } from "../components/ComponentViewerBox";
 import { Screen } from "../components/Screen";
 
@@ -160,11 +162,17 @@ const mockRadioItems = (): ReadonlyArray<RadioItem<string>> => [
     id: "example-icon"
   },
   {
-    startImage: { paymentLogo: "myBank" },
-    value: "Let's try with a basic title",
-    description:
-      "Ti contatteranno solo i servizi che hanno qualcosa di importante da dirti. Potrai sempre disattivare le comunicazioni che non ti interessano.",
-    id: "example-paymentLogo"
+    value: "Let's try with JSX description",
+    description: (
+      <LabelSmall color="grey-700" weight="Regular">
+        Ti contatteranno solo i servizi che hanno qualcosa di importante da
+        dirti.{" "}
+        <Text style={{ color: IOColors["grey-700"], fontWeight: "600" }}>
+          Potrai sempre disattivare le comunicazioni che non ti interessano.
+        </Text>
+      </LabelSmall>
+    ),
+    id: "example-jsx-element"
   },
   {
     value: "Let's try with a basic title",

--- a/src/components/listitems/ListItemRadio.tsx
+++ b/src/components/listitems/ListItemRadio.tsx
@@ -47,7 +47,7 @@ type ListItemRadioLoadingProps =
 
 type Props = WithTestID<{
   value: string;
-  description?: string;
+  description?: string | React.ReactNode;
   selected: boolean;
   onValueChange?: (newValue: boolean) => void;
   startImage?: ListItemRadioGraphicProps;

--- a/src/components/radio/RadioGroup.tsx
+++ b/src/components/radio/RadioGroup.tsx
@@ -5,7 +5,7 @@ import { ListItemRadio, ListItemRadioWithAmount } from "../listitems";
 export type RadioItem<T> = {
   id: T;
   value: string;
-  description?: string;
+  description?: string | React.ReactNode;
   disabled?: boolean;
   startImage?: ComponentProps<typeof ListItemRadio>["startImage"];
   loadingProps?: ComponentProps<typeof ListItemRadio>["loadingProps"];


### PR DESCRIPTION
## Short description
On RadioGroup component change type of description from `string` to `string | React.ReactNode` to accept ad JSX as description. 

## List of changes proposed in this pull request
- change type of description
- update example on example app 

<img width="250" alt="example app" src="https://github.com/pagopa/io-app-design-system/assets/83651704/c1f8852d-994e-4dda-85d4-a39ddf181a90">

## How to test
Run the example app and navigate to the 'Selection' section. As you can see from the screenshoot, the item I added has the title "Let's try with JSX description".