### PR TITLE
chore: Add Ref prop to Button components

### DIFF
--- a/src/components/buttons/ButtonLink.tsx
+++ b/src/components/buttons/ButtonLink.tsx
@@ -1,5 +1,10 @@
 import React, { useCallback, useMemo } from "react";
-import { GestureResponderEvent, Pressable, StyleSheet } from "react-native";
+import {
+  GestureResponderEvent,
+  Pressable,
+  StyleSheet,
+  View
+} from "react-native";
 import Animated, {
   Extrapolate,
   interpolate,
@@ -112,18 +117,21 @@ const IOButtonLegacyStylesLocal = StyleSheet.create({
   }
 });
 
-export const ButtonLink = React.memo(
-  ({
-    color = "primary",
-    label,
-    disabled = false,
-    icon,
-    iconPosition = "start",
-    onPress,
-    accessibilityLabel,
-    accessibilityHint,
-    testID
-  }: ButtonLinkProps) => {
+export const ButtonLink = React.forwardRef<View, ButtonLinkProps>(
+  (
+    {
+      color = "primary",
+      label,
+      disabled = false,
+      icon,
+      iconPosition = "start",
+      onPress,
+      accessibilityLabel,
+      accessibilityHint,
+      testID
+    },
+    ref
+  ) => {
     const isPressed = useSharedValue(0);
     const { isExperimental } = useIOExperimentalDesign();
 
@@ -203,6 +211,7 @@ export const ButtonLink = React.memo(
 
     return (
       <Pressable
+        ref={ref}
         accessibilityLabel={accessibilityLabel}
         accessibilityHint={accessibilityHint}
         accessibilityRole={"button"}

--- a/src/components/buttons/ButtonOutline.tsx
+++ b/src/components/buttons/ButtonOutline.tsx
@@ -1,5 +1,10 @@
 import React, { useCallback } from "react";
-import { GestureResponderEvent, Pressable, StyleSheet } from "react-native";
+import {
+  GestureResponderEvent,
+  Pressable,
+  StyleSheet,
+  View
+} from "react-native";
 import Animated, {
   Extrapolate,
   interpolate,
@@ -213,183 +218,189 @@ const IOButtonStylesLocal = StyleSheet.create({
   }
 });
 
-export const ButtonOutline = ({
-  color = "primary",
-  label,
-  fullWidth = false,
-  disabled = false,
-  icon,
-  iconPosition = "start",
-  onPress,
-  accessibilityLabel,
-  accessibilityHint,
-  testID
-}: ButtonOutline) => {
-  const { isExperimental } = useIOExperimentalDesign();
-  const isPressed: Animated.SharedValue<number> = useSharedValue(0);
+export const ButtonOutline = React.forwardRef<View, ButtonOutline>(
+  (
+    {
+      color = "primary",
+      label,
+      fullWidth = false,
+      disabled = false,
+      icon,
+      iconPosition = "start",
+      onPress,
+      accessibilityLabel,
+      accessibilityHint,
+      testID
+    },
+    ref
+  ) => {
+    const { isExperimental } = useIOExperimentalDesign();
+    const isPressed: Animated.SharedValue<number> = useSharedValue(0);
 
-  const colorMap = React.useMemo(
-    () => (isExperimental ? mapColorStates : mapLegacyColorStates),
-    [isExperimental]
-  );
-
-  const buttonStyles = React.useMemo(
-    () => (isExperimental ? IOButtonStyles : IOButtonLegacyStyles),
-    [isExperimental]
-  );
-
-  const buttonStylesLocal = React.useMemo(
-    () => (isExperimental ? IOButtonStylesLocal : IOButtonLegacyStylesLocal),
-    [isExperimental]
-  );
-  // Scaling transformation applied when the button is pressed
-  const animationScaleValue = IOScaleValues?.basicButton?.pressedState;
-
-  // Using a spring-based animation for our interpolations
-  const progressPressed = useDerivedValue(() =>
-    withSpring(isPressed.value, IOSpringValues.button)
-  );
-
-  // Interpolate animation values from `isPressed` values
-  const pressedAnimationStyle = useAnimatedStyle(() => {
-    // Link color states to the pressed states
-    const backgroundColor = interpolateColor(
-      progressPressed.value,
-      [0, 1],
-      [colorMap[color].background.default, colorMap[color].background.pressed]
+    const colorMap = React.useMemo(
+      () => (isExperimental ? mapColorStates : mapLegacyColorStates),
+      [isExperimental]
     );
 
-    const borderColor = interpolateColor(
-      progressPressed.value,
-      [0, 1],
-      [colorMap[color].border.default, colorMap[color].border.pressed]
+    const buttonStyles = React.useMemo(
+      () => (isExperimental ? IOButtonStyles : IOButtonLegacyStyles),
+      [isExperimental]
     );
 
-    // Scale down button slightly when pressed
-    const scale = interpolate(
-      progressPressed.value,
-      [0, 1],
-      [1, animationScaleValue],
-      Extrapolate.CLAMP
+    const buttonStylesLocal = React.useMemo(
+      () => (isExperimental ? IOButtonStylesLocal : IOButtonLegacyStylesLocal),
+      [isExperimental]
+    );
+    // Scaling transformation applied when the button is pressed
+    const animationScaleValue = IOScaleValues?.basicButton?.pressedState;
+
+    // Using a spring-based animation for our interpolations
+    const progressPressed = useDerivedValue(() =>
+      withSpring(isPressed.value, IOSpringValues.button)
     );
 
-    return {
-      borderColor,
-      backgroundColor,
-      transform: [{ scale }]
-    };
-  });
+    // Interpolate animation values from `isPressed` values
+    const pressedAnimationStyle = useAnimatedStyle(() => {
+      // Link color states to the pressed states
+      const backgroundColor = interpolateColor(
+        progressPressed.value,
+        [0, 1],
+        [colorMap[color].background.default, colorMap[color].background.pressed]
+      );
 
-  const pressedColorLabelAnimationStyle = useAnimatedStyle(() => {
-    // Link color states to the pressed states
+      const borderColor = interpolateColor(
+        progressPressed.value,
+        [0, 1],
+        [colorMap[color].border.default, colorMap[color].border.pressed]
+      );
 
-    const labelColor = interpolateColor(
-      progressPressed.value,
-      [0, 1],
-      [colorMap[color].border.default, colorMap[color].border.pressed]
-    );
+      // Scale down button slightly when pressed
+      const scale = interpolate(
+        progressPressed.value,
+        [0, 1],
+        [1, animationScaleValue],
+        Extrapolate.CLAMP
+      );
 
-    return {
-      color: labelColor
-    };
-  });
+      return {
+        borderColor,
+        backgroundColor,
+        transform: [{ scale }]
+      };
+    });
 
-  // Animate the <Icon> color prop
-  const pressedColorIconAnimationStyle = useAnimatedProps(() => {
-    const iconColor = interpolateColor(
-      progressPressed.value,
-      [0, 1],
-      [colorMap[color].label.default, colorMap[color].label.pressed]
-    );
-    return { color: iconColor };
-  });
+    const pressedColorLabelAnimationStyle = useAnimatedStyle(() => {
+      // Link color states to the pressed states
 
-  const AnimatedIconClassComponent =
-    Animated.createAnimatedComponent(IconClassComponent);
+      const labelColor = interpolateColor(
+        progressPressed.value,
+        [0, 1],
+        [colorMap[color].border.default, colorMap[color].border.pressed]
+      );
 
-  const onPressIn = useCallback(() => {
-    // eslint-disable-next-line functional/immutable-data
-    isPressed.value = 1;
-  }, [isPressed]);
-  const onPressOut = useCallback(() => {
-    // eslint-disable-next-line functional/immutable-data
-    isPressed.value = 0;
-  }, [isPressed]);
+      return {
+        color: labelColor
+      };
+    });
 
-  return (
-    <Pressable
-      accessibilityLabel={accessibilityLabel}
-      accessibilityHint={accessibilityHint}
-      accessibilityRole={"button"}
-      testID={testID}
-      onPress={onPress}
-      onPressIn={onPressIn}
-      onPressOut={onPressOut}
-      accessible={true}
-      disabled={disabled}
-      style={!fullWidth ? IOButtonStyles.dimensionsDefault : {}}
-    >
-      <Animated.View
-        style={[
-          buttonStyles.button,
-          isExperimental && fullWidth && { paddingHorizontal: 16 },
-          buttonStylesLocal.buttonWithBorder,
-          buttonStyles.buttonSizeDefault,
-          iconPosition === "end" && { flexDirection: "row-reverse" },
-          disabled
-            ? {
-                backgroundColor: colorMap[color]?.background?.disabled,
-                borderColor: colorMap[color]?.border?.disabled,
-                opacity: DISABLED_OPACITY
-              }
-            : {
-                backgroundColor: colorMap[color]?.background?.default,
-                borderColor: colorMap[color]?.border.default
-              },
-          /* Prevent Reanimated from overriding background colors
-                    if button is disabled */
-          !disabled && pressedAnimationStyle
-        ]}
+    // Animate the <Icon> color prop
+    const pressedColorIconAnimationStyle = useAnimatedProps(() => {
+      const iconColor = interpolateColor(
+        progressPressed.value,
+        [0, 1],
+        [colorMap[color].label.default, colorMap[color].label.pressed]
+      );
+      return { color: iconColor };
+    });
+
+    const AnimatedIconClassComponent =
+      Animated.createAnimatedComponent(IconClassComponent);
+
+    const onPressIn = useCallback(() => {
+      // eslint-disable-next-line functional/immutable-data
+      isPressed.value = 1;
+    }, [isPressed]);
+    const onPressOut = useCallback(() => {
+      // eslint-disable-next-line functional/immutable-data
+      isPressed.value = 0;
+    }, [isPressed]);
+
+    return (
+      <Pressable
+        ref={ref}
+        accessibilityLabel={accessibilityLabel}
+        accessibilityHint={accessibilityHint}
+        accessibilityRole={"button"}
+        testID={testID}
+        onPress={onPress}
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
+        accessible={true}
+        disabled={disabled}
+        style={!fullWidth ? IOButtonStyles.dimensionsDefault : {}}
       >
-        {icon && (
-          <>
-            {!disabled ? (
-              <AnimatedIconClassComponent
-                name={icon}
-                animatedProps={pressedColorIconAnimationStyle}
-                color={colorMap[color]?.label?.default}
-                size={iconSize}
-              />
-            ) : (
-              <AnimatedIcon
-                name={icon}
-                color={colorMap[color]?.label?.disabled}
-                size={iconSize}
-              />
-            )}
-            <HSpacer size={8} />
-          </>
-        )}
-        <Animated.Text
+        <Animated.View
           style={[
-            buttonStylesLocal.label,
-            buttonStyles.label,
+            buttonStyles.button,
+            isExperimental && fullWidth && { paddingHorizontal: 16 },
+            buttonStylesLocal.buttonWithBorder,
+            buttonStyles.buttonSizeDefault,
+            iconPosition === "end" && { flexDirection: "row-reverse" },
             disabled
-              ? { color: colorMap[color]?.label?.disabled }
-              : { color: colorMap[color]?.label?.default },
-            !disabled && pressedColorLabelAnimationStyle
+              ? {
+                  backgroundColor: colorMap[color]?.background?.disabled,
+                  borderColor: colorMap[color]?.border?.disabled,
+                  opacity: DISABLED_OPACITY
+                }
+              : {
+                  backgroundColor: colorMap[color]?.background?.default,
+                  borderColor: colorMap[color]?.border.default
+                },
+            /* Prevent Reanimated from overriding background colors
+                    if button is disabled */
+            !disabled && pressedAnimationStyle
           ]}
-          numberOfLines={1}
-          ellipsizeMode="tail"
-          allowFontScaling={isExperimental}
-          maxFontSizeMultiplier={1.3}
-          importantForAccessibility="no-hide-descendants"
         >
-          {label}
-        </Animated.Text>
-      </Animated.View>
-    </Pressable>
-  );
-};
+          {icon && (
+            <>
+              {!disabled ? (
+                <AnimatedIconClassComponent
+                  name={icon}
+                  animatedProps={pressedColorIconAnimationStyle}
+                  color={colorMap[color]?.label?.default}
+                  size={iconSize}
+                />
+              ) : (
+                <AnimatedIcon
+                  name={icon}
+                  color={colorMap[color]?.label?.disabled}
+                  size={iconSize}
+                />
+              )}
+              <HSpacer size={8} />
+            </>
+          )}
+          <Animated.Text
+            style={[
+              buttonStylesLocal.label,
+              buttonStyles.label,
+              disabled
+                ? { color: colorMap[color]?.label?.disabled }
+                : { color: colorMap[color]?.label?.default },
+              !disabled && pressedColorLabelAnimationStyle
+            ]}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            allowFontScaling={isExperimental}
+            maxFontSizeMultiplier={1.3}
+            importantForAccessibility="no-hide-descendants"
+          >
+            {label}
+          </Animated.Text>
+        </Animated.View>
+      </Pressable>
+    );
+  }
+);
 
 export default ButtonOutline;

--- a/src/components/buttons/ButtonSolid.tsx
+++ b/src/components/buttons/ButtonSolid.tsx
@@ -1,5 +1,10 @@
 import React, { useCallback, useEffect, useRef } from "react";
-import { GestureResponderEvent, Pressable, StyleSheet } from "react-native";
+import {
+  GestureResponderEvent,
+  Pressable,
+  StyleSheet,
+  View
+} from "react-native";
 import ReactNativeHapticFeedback from "react-native-haptic-feedback";
 import Animated, {
   Extrapolate,
@@ -155,20 +160,23 @@ const mapLegacyColorStates: Record<
   }
 };
 
-export const ButtonSolid = React.memo(
-  ({
-    color = "primary",
-    label,
-    fullWidth = false,
-    disabled = false,
-    loading = false,
-    icon,
-    iconPosition = "start",
-    onPress,
-    accessibilityLabel,
-    accessibilityHint,
-    testID
-  }: ButtonSolidProps) => {
+export const ButtonSolid = React.forwardRef<View, ButtonSolidProps>(
+  (
+    {
+      color = "primary",
+      label,
+      fullWidth = false,
+      disabled = false,
+      loading = false,
+      icon,
+      iconPosition = "start",
+      onPress,
+      accessibilityLabel,
+      accessibilityHint,
+      testID
+    },
+    ref
+  ) => {
     const isPressed = useSharedValue(0);
     const { isExperimental } = useIOExperimentalDesign();
     // Scaling transformation applied when the button is pressed
@@ -253,6 +261,7 @@ export const ButtonSolid = React.memo(
     return (
       <Pressable
         testID={testID}
+        ref={ref}
         accessible={true}
         accessibilityLabel={accessibilityLabel}
         accessibilityHint={accessibilityHint}

--- a/src/components/layout/BlockButtons.tsx
+++ b/src/components/layout/BlockButtons.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { View, StyleSheet } from "react-native";
 import { HSpacer } from "../spacer/Spacer";
-import { ButtonOutline, ButtonSolid, ButtonSolidProps } from "../buttons";
+import { ButtonOutline, ButtonSolid } from "../buttons";
 import { IOStyles } from "../../core";
 
 const styles = StyleSheet.create({
@@ -23,7 +23,7 @@ type CommonProps = Readonly<{
 
 export type BlockButtonProps = {
   type: "Solid" | "Outline";
-  buttonProps: Omit<ButtonSolidProps, "fullWidth">;
+  buttonProps: Omit<React.ComponentProps<typeof ButtonSolid>, "fullWidth">;
 };
 
 /**


### PR DESCRIPTION
## Short description
This PR adds the forwardRef definition to button components.

## List of changes proposed in this pull request
- Adds `React.forwardRef` definition to `ButtonSolid`, `ButtonOutline`, `ButtonLink`

## How to test
Ref should be propagated without warnings.
