### PR TITLE
chore: Proper accessibility on ListItemInfoCopy on Android

### DIFF
--- a/src/components/listitems/ListItemInfoCopy.tsx
+++ b/src/components/listitems/ListItemInfoCopy.tsx
@@ -125,6 +125,7 @@ export const ListItemInfoCopy = ({
       testID={testID}
     >
       <Animated.View
+        importantForAccessibility="no-hide-descendants"
         style={[IOListItemStyles.listItem, animatedBackgroundStyle]}
       >
         <Animated.View

--- a/src/components/listitems/__test__/__snapshots__/listitem.test.tsx.snap
+++ b/src/components/listitems/__test__/__snapshots__/listitem.test.tsx.snap
@@ -332,6 +332,7 @@ exports[`Test List Item Components - Experimental Enabled  ListItemInfoCopy Snap
   onStartShouldSetResponder={[Function]}
 >
   <View
+    importantForAccessibility="no-hide-descendants"
     style={
       [
         {
@@ -2063,6 +2064,7 @@ exports[`Test List Item Components ListItemInfoCopy Snapshot 1`] = `
   onStartShouldSetResponder={[Function]}
 >
   <View
+    importantForAccessibility="no-hide-descendants"
     style={
       [
         {


### PR DESCRIPTION
## Short description
This PR fixes the accessibility on `ListItemInfoCopy` for Android.

## List of changes proposed in this pull request
- `no-hide-descendents` added on the child view of the `Pressable` component in the `ListItemInfoCopy`, in order to prevent the internal views to be read twice by the TalkBack