### PR TITLE
[IOAPPX-260] Update `Avatar` component, deprecate `shape` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Common functions used to wrap up external libraries and utilities
 * [`react-native-haptic-feedback`](https://github.com/mkuczera/react-native-haptic-feedback): Handles all the haptic feedbacks
 * [`react-native-safe-area-context`](https://github.com/th3rdwave/react-native-safe-area-context): Handles all safe area spacing attributes
 * [`react-native-linear-gradient`](https://github.com/react-native-linear-gradient/react-native-linear-gradient)
+* [`react-native-easing-gradient`](https://github.com/phamfoo/react-native-easing-gradient): Generates easing gradients
 * [`react-native-gesture-handler`](https://github.com/software-mansion/react-native-gesture-handler)
 
 ---

--- a/example/src/pages/Logos.tsx
+++ b/example/src/pages/Logos.tsx
@@ -142,7 +142,7 @@ const organizationsURIs = [
 
 const renderAvatar = () => (
   <>
-    <ComponentViewerBox name={`Avatar, small size, circle shape`}>
+    <ComponentViewerBox name={`Avatar, small size, square shape`}>
       <ScrollView
         horizontal={true}
         showsHorizontalScrollIndicator={false}
@@ -151,33 +151,6 @@ const renderAvatar = () => (
         {organizationsURIs.map(({ imageSource }, i) => (
           <React.Fragment key={i}>
             <Avatar
-              shape="circle"
-              size="small"
-              logoUri={
-                imageSource
-                  ? Array.isArray(imageSource)
-                    ? imageSource.map(s => ({ uri: s }))
-                    : {
-                        uri: imageSource
-                      }
-                  : undefined
-              }
-            />
-            {i < organizationsURIs.length - 1 && <HSpacer size={4} />}
-          </React.Fragment>
-        ))}
-      </ScrollView>
-    </ComponentViewerBox>
-    {/* <ComponentViewerBox name={`Avatar, small size, square shape`}>
-      <ScrollView
-        horizontal={true}
-        showsHorizontalScrollIndicator={false}
-        style={styles.horizontalScroll}
-      >
-        {organizationsURIs.map(({ imageSource }, i) => (
-          <React.Fragment key={i}>
-            <Avatar
-              shape="square"
               size="small"
               logoUri={
                 imageSource
@@ -203,7 +176,6 @@ const renderAvatar = () => (
         {organizationsURIs.map(({ imageSource }, i) => (
           <React.Fragment key={i}>
             <Avatar
-              shape="square"
               size="medium"
               logoUri={
                 imageSource
@@ -219,7 +191,7 @@ const renderAvatar = () => (
           </React.Fragment>
         ))}
       </ScrollView>
-    </ComponentViewerBox> */}
+    </ComponentViewerBox>
   </>
 );
 

--- a/example/src/pages/Selection.tsx
+++ b/example/src/pages/Selection.tsx
@@ -1,8 +1,11 @@
 import {
+  AnimatedMessageCheckbox,
   CheckboxLabel,
   Divider,
   H2,
+  HSpacer,
   IOColors,
+  IOStyles,
   IOVisualCostants,
   LabelSmall,
   ListItemCheckbox,
@@ -42,6 +45,9 @@ export const Selection = () => {
       {renderCheckboxLabel()}
       {/* ListItemCheckbox */}
       {renderListItemCheckbox()}
+      {/* AnimatedMessageCheckbox */}
+      <H2 style={{ marginVertical: 16 }}>Checkbox (Messages)</H2>
+      <AnimatedMessageCheckboxShowroom />
       <H2 style={{ marginVertical: 16 }}>Radio</H2>
       {/* RadioButtonLabel */}
       {renderRadioButtonLabel()}
@@ -151,6 +157,22 @@ const renderListItemCheckbox = () => (
   </>
 );
 
+const AnimatedMessageCheckboxShowroom = () => {
+  const [isEnabled, setIsEnabled] = useState(true);
+  const toggleSwitch = () => setIsEnabled(previousState => !previousState);
+
+  return (
+    <>
+      <ComponentViewerBox name="AnimatedMessageCheckbox">
+        <View style={[IOStyles.row, IOStyles.alignCenter]}>
+          <AnimatedMessageCheckbox checked={isEnabled} />
+          <HSpacer size={24} />
+          <NativeSwitch onValueChange={toggleSwitch} value={isEnabled} />
+        </View>
+      </ComponentViewerBox>
+    </>
+  );
+};
 // RADIO ITEMS
 
 const mockRadioItems = (): ReadonlyArray<RadioItem<string>> => [

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "react-native-gesture-handler": "*",
     "react-native-haptic-feedback": "*",
     "react-native-linear-gradient": "*",
+    "react-native-easing-gradient": "*",
     "react-native-reanimated": "*",
     "react-native-safe-area-context": "*",
     "react-native-svg": "*"

--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -11,42 +11,47 @@ import {
 import { addCacheTimestampToUri } from "../../utils/image";
 
 type Avatar = {
-  shape: "circle" | "square";
+  imageSource?: ImageURISource | ReadonlyArray<ImageURISource>;
+  /**
+   * @deprecated Only `square` shape variant accepted
+   */
+  shape?: "circle" | "square";
   size: "small" | "medium";
   logoUri?: ImageURISource | ReadonlyArray<ImageURISource>;
 };
 
-const avatarBorderLightMode = hexToRgba(IOColors.black, 0.1);
 const internalSpaceDefaultSize: number = 6;
 const internalSpaceLargeSize: number = 9;
-const radiusDefaultSize: number = 8;
 const internalSpacePlaceholderDefaultSize: IOSpacingScale = 12;
 const internalSpacePlaceholderLargeSize: IOSpacingScale = 16;
+const avatarBorderLightMode = hexToRgba(IOColors.black, 0.1);
 
 const dimensionsMap = {
   small: {
     size: IOVisualCostants.avatarSizeSmall,
     internalSpace: internalSpaceDefaultSize,
     internalSpacePlaceholder: internalSpacePlaceholderDefaultSize,
-    radius: radiusDefaultSize
+    radius: IOVisualCostants.avatarRadius
   },
   medium: {
     size: IOVisualCostants.avatarSizeMedium,
     internalSpace: internalSpaceLargeSize,
     internalSpacePlaceholder: internalSpacePlaceholderLargeSize,
-    radius: radiusDefaultSize
+    radius: IOVisualCostants.avatarRadius
   }
 };
-
-const getAvatarCircleShape = (size: Avatar["size"]) =>
-  dimensionsMap[size].size / 2;
 
 const styles = StyleSheet.create({
   avatarWrapper: {
     overflow: "hidden",
-    resizeMode: "contain",
     borderColor: avatarBorderLightMode,
     borderWidth: 1,
+    borderCurve: "continuous"
+  },
+  avatarInnerWrapper: {
+    overflow: "hidden",
+    resizeMode: "contain",
+    backgroundColor: IOColors.white,
     borderCurve: "continuous"
   },
   avatarImage: {
@@ -63,7 +68,7 @@ const styles = StyleSheet.create({
  * @param AvatarProps
  * @returns
  */
-export const Avatar = ({ logoUri, shape, size }: Avatar) => {
+export const Avatar = ({ logoUri, size }: Avatar) => {
   const theme = useIOTheme();
   const indexValue = React.useRef<number>(0);
 
@@ -92,10 +97,7 @@ export const Avatar = ({ logoUri, shape, size }: Avatar) => {
         {
           height: dimensionsMap[size].size,
           width: dimensionsMap[size].size,
-          borderRadius:
-            shape === "circle"
-              ? getAvatarCircleShape(size)
-              : dimensionsMap[size].radius,
+          borderRadius: dimensionsMap[size].radius,
           backgroundColor:
             imageSource === undefined ? IOColors["grey-50"] : IOColors.white,
           padding:
@@ -112,11 +114,21 @@ export const Avatar = ({ logoUri, shape, size }: Avatar) => {
           size={"100%"}
         />
       ) : (
-        <Image
-          source={imageSource}
-          style={styles.avatarImage}
-          onError={onError}
-        />
+        <View
+          style={[
+            styles.avatarInnerWrapper,
+            {
+              borderRadius:
+                dimensionsMap[size].radius - dimensionsMap[size].internalSpace
+            }
+          ]}
+        >
+          <Image
+            source={imageSource}
+            style={styles.avatarImage}
+            onError={onError}
+          />
+        </View>
       )}
     </View>
   );

--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -31,13 +31,13 @@ const dimensionsMap = {
     size: IOVisualCostants.avatarSizeSmall,
     internalSpace: internalSpaceDefaultSize,
     internalSpacePlaceholder: internalSpacePlaceholderDefaultSize,
-    radius: IOVisualCostants.avatarRadius
+    radius: IOVisualCostants.avatarRadiusSizeSmall
   },
   medium: {
     size: IOVisualCostants.avatarSizeMedium,
     internalSpace: internalSpaceLargeSize,
     internalSpacePlaceholder: internalSpacePlaceholderLargeSize,
-    radius: IOVisualCostants.avatarRadius
+    radius: IOVisualCostants.avatarRadiusSizeMedium
   }
 };
 

--- a/src/components/avatar/__test__/__snapshots__/avatar.test.tsx.snap
+++ b/src/components/avatar/__test__/__snapshots__/avatar.test.tsx.snap
@@ -9,11 +9,10 @@ exports[`Test Avatar Components - Experimental Enabled Avatar Snapshot 1`] = `
         "borderCurve": "continuous",
         "borderWidth": 1,
         "overflow": "hidden",
-        "resizeMode": "contain",
       },
       {
         "backgroundColor": "#FFFFFF",
-        "borderRadius": 22,
+        "borderRadius": 8,
         "height": 44,
         "padding": 6,
         "width": 44,
@@ -21,20 +20,36 @@ exports[`Test Avatar Components - Experimental Enabled Avatar Snapshot 1`] = `
     ]
   }
 >
-  <Image
-    onError={[Function]}
-    source={
-      {
-        "uri": "",
-      }
-    }
+  <View
     style={
-      {
-        "height": "100%",
-        "width": "100%",
-      }
+      [
+        {
+          "backgroundColor": "#FFFFFF",
+          "borderCurve": "continuous",
+          "overflow": "hidden",
+          "resizeMode": "contain",
+        },
+        {
+          "borderRadius": 2,
+        },
+      ]
     }
-  />
+  >
+    <Image
+      onError={[Function]}
+      source={
+        {
+          "uri": "",
+        }
+      }
+      style={
+        {
+          "height": "100%",
+          "width": "100%",
+        }
+      }
+    />
+  </View>
 </View>
 `;
 
@@ -47,11 +62,10 @@ exports[`Test Avatar Components Avatar Snapshot 1`] = `
         "borderCurve": "continuous",
         "borderWidth": 1,
         "overflow": "hidden",
-        "resizeMode": "contain",
       },
       {
         "backgroundColor": "#FFFFFF",
-        "borderRadius": 22,
+        "borderRadius": 8,
         "height": 44,
         "padding": 6,
         "width": 44,
@@ -59,19 +73,35 @@ exports[`Test Avatar Components Avatar Snapshot 1`] = `
     ]
   }
 >
-  <Image
-    onError={[Function]}
-    source={
-      {
-        "uri": "",
-      }
-    }
+  <View
     style={
-      {
-        "height": "100%",
-        "width": "100%",
-      }
+      [
+        {
+          "backgroundColor": "#FFFFFF",
+          "borderCurve": "continuous",
+          "overflow": "hidden",
+          "resizeMode": "contain",
+        },
+        {
+          "borderRadius": 2,
+        },
+      ]
     }
-  />
+  >
+    <Image
+      onError={[Function]}
+      source={
+        {
+          "uri": "",
+        }
+      }
+      style={
+        {
+          "height": "100%",
+          "width": "100%",
+        }
+      }
+    />
+  </View>
 </View>
 `;

--- a/src/components/checkbox/AnimatedMessageCheckbox.tsx
+++ b/src/components/checkbox/AnimatedMessageCheckbox.tsx
@@ -33,13 +33,13 @@ const styles = StyleSheet.create({
     height: IOVisualCostants.avatarSizeSmall,
     padding: internalSpacing
   },
-  checkBoxCircle: {
+  checkBoxShape: {
     position: "absolute",
     left: 0,
     top: 0,
     width: IOVisualCostants.avatarSizeSmall,
     height: IOVisualCostants.avatarSizeSmall,
-    borderRadius: IOVisualCostants.avatarRadius,
+    borderRadius: IOVisualCostants.avatarRadiusSizeSmall,
     borderCurve: "continuous"
   }
 });
@@ -97,7 +97,7 @@ export const AnimatedMessageCheckbox = ({
     >
       <Animated.View
         style={[
-          styles.checkBoxCircle,
+          styles.checkBoxShape,
           {
             backgroundColor: backgroundColorProp
           },

--- a/src/components/checkbox/AnimatedMessageCheckbox.tsx
+++ b/src/components/checkbox/AnimatedMessageCheckbox.tsx
@@ -39,7 +39,8 @@ const styles = StyleSheet.create({
     top: 0,
     width: IOVisualCostants.avatarSizeSmall,
     height: IOVisualCostants.avatarSizeSmall,
-    borderRadius: IOVisualCostants.avatarSizeSmall
+    borderRadius: IOVisualCostants.avatarRadius,
+    borderCurve: "continuous"
   }
 });
 

--- a/src/core/IOStyles.ts
+++ b/src/core/IOStyles.ts
@@ -21,6 +21,7 @@ interface IOVisualCostants {
   // Dimensions
   avatarSizeSmall: number;
   avatarSizeMedium: number;
+  avatarRadius: number;
   iconContainedSizeDefault: number;
   scrollDownButtonRight: number;
   scrollDownButtonBottom: number;
@@ -31,6 +32,7 @@ export const IOVisualCostants: IOVisualCostants = {
   headerHeight: 56,
   avatarSizeSmall: 44,
   avatarSizeMedium: 66,
+  avatarRadius: 12,
   iconContainedSizeDefault: 44,
   scrollDownButtonRight: 24,
   scrollDownButtonBottom: 24

--- a/src/core/IOStyles.ts
+++ b/src/core/IOStyles.ts
@@ -21,7 +21,8 @@ interface IOVisualCostants {
   // Dimensions
   avatarSizeSmall: number;
   avatarSizeMedium: number;
-  avatarRadius: number;
+  avatarRadiusSizeSmall: number;
+  avatarRadiusSizeMedium: number;
   iconContainedSizeDefault: number;
   scrollDownButtonRight: number;
   scrollDownButtonBottom: number;
@@ -32,7 +33,8 @@ export const IOVisualCostants: IOVisualCostants = {
   headerHeight: 56,
   avatarSizeSmall: 44,
   avatarSizeMedium: 66,
-  avatarRadius: 12,
+  avatarRadiusSizeSmall: 8,
+  avatarRadiusSizeMedium: 12,
   iconContainedSizeDefault: 44,
   scrollDownButtonRight: 24,
   scrollDownButtonBottom: 24


### PR DESCRIPTION
## Short description
This PR updates the `Avatar` component with an inner rounded wrapper to handle edge cases (entity logos without rounded shapes, etc...). It also deprecates the `shape` prop because the rounded square is the only accepted variant.

## List of changes proposed in this pull request
- Add two different radius values: `8` for small version, `12` for medium one
- Link the shape radius value to the `AnimatedMessageCheckbox` component
- Deprecate `shape` prop using JSDoc syntax
- **[Extra]** Add `react-native-easing-gradient` as peer dependency

### Preview

https://github.com/pagopa/io-app-design-system/assets/1255491/5f33f7be-593a-4b21-a2b8-85f35ee485e1



## How to test
1. Launch the example app
2. Go to the **Logos** page