### PR TITLE
[IOAPPX-262] Make *Selection* components dark mode compatible

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
 import {
   IODSExperimentalContextProvider,
   IOThemeContextProvider,
   ToastProvider
 } from "@pagopa/io-app-design-system";
+import * as React from "react";
 import { useColorScheme } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import AppNavigator from "./navigation/navigator";
@@ -13,13 +13,15 @@ export default function App() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <IOThemeContextProvider theme={colorScheme === "dark" ? "dark" : "light"}>
-        <IODSExperimentalContextProvider>
+      <IODSExperimentalContextProvider>
+        <IOThemeContextProvider
+          theme={colorScheme === "dark" ? "dark" : "light"}
+        >
           <ToastProvider>
             <AppNavigator />
           </ToastProvider>
-        </IODSExperimentalContextProvider>
-      </IOThemeContextProvider>
+        </IOThemeContextProvider>
+      </IODSExperimentalContextProvider>
     </GestureHandlerRootView>
   );
 }

--- a/example/src/pages/NumberPad.tsx
+++ b/example/src/pages/NumberPad.tsx
@@ -10,7 +10,7 @@ import {
   ListItemSwitch,
   NumberPad,
   VSpacer,
-  useIOExperimentalDesign
+  useIOTheme
 } from "@pagopa/io-app-design-system";
 import { useNavigation } from "@react-navigation/native";
 import * as React from "react";
@@ -22,16 +22,11 @@ const PIN_LENGTH = 6;
  * @returns a screen with a flexed view where you can test components
  */
 export const NumberPadScreen = () => {
+  const theme = useIOTheme();
+  const navigation = useNavigation();
+
   const [value, setValue] = React.useState("");
   const [blueBackground, setBlueBackground] = React.useState(false);
-  const { isExperimental } = useIOExperimentalDesign();
-
-  const primaryBackground = React.useMemo(
-    () => (isExperimental ? IOColors["blueIO-500"] : IOColors.blue),
-    [isExperimental]
-  );
-
-  const navigation = useNavigation();
 
   const onValueChange = (v: string) => {
     if (v.length <= PIN_LENGTH) {
@@ -42,16 +37,21 @@ export const NumberPadScreen = () => {
   React.useEffect(() => {
     navigation.setOptions({
       headerStyle: {
-        backgroundColor: blueBackground ? primaryBackground : IOColors.white
+        backgroundColor: blueBackground
+          ? IOColors[theme["appBackground-accent"]]
+          : IOColors.white
       }
     });
-  }, [blueBackground, primaryBackground, navigation]);
+  }, [blueBackground, navigation, theme]);
+
   return (
     <View
       style={{
         flexGrow: 1,
         paddingVertical: IOVisualCostants.appMarginDefault,
-        backgroundColor: blueBackground ? primaryBackground : IOColors.white
+        backgroundColor: blueBackground
+          ? IOColors[theme["appBackground-accent"]]
+          : IOColors.white
       }}
     >
       <ContentWrapper>

--- a/example/src/pages/Selection.tsx
+++ b/example/src/pages/Selection.tsx
@@ -17,7 +17,8 @@ import {
   RadioItemWithAmount,
   SwitchLabel,
   VSpacer,
-  useIOExperimentalDesign
+  useIOExperimentalDesign,
+  useIOTheme
 } from "@pagopa/io-app-design-system";
 import React, { useState } from "react";
 import { Text, View } from "react-native";
@@ -26,9 +27,12 @@ import { Screen } from "../components/Screen";
 
 export const Selection = () => {
   const { isExperimental, setExperimental } = useIOExperimentalDesign();
+  const theme = useIOTheme();
+
   return (
     <Screen>
       <H2
+        color={theme["textBody-default"]}
         style={{
           marginVertical: 16,
           paddingTop: IOVisualCostants.appMarginDefault
@@ -46,16 +50,22 @@ export const Selection = () => {
       {/* ListItemCheckbox */}
       {renderListItemCheckbox()}
       {/* AnimatedMessageCheckbox */}
-      <H2 style={{ marginVertical: 16 }}>Checkbox (Messages)</H2>
+      <H2 color={theme["textBody-default"]} style={{ marginVertical: 16 }}>
+        Checkbox (Messages)
+      </H2>
       <AnimatedMessageCheckboxShowroom />
-      <H2 style={{ marginVertical: 16 }}>Radio</H2>
+      <H2 color={theme["textBody-default"]} style={{ marginVertical: 16 }}>
+        Radio
+      </H2>
       {/* RadioButtonLabel */}
       {renderRadioButtonLabel()}
       {/* RadioListItem */}
       <RadioListItemsShowroom />
       {/* RadioListItemWithAmount */}
       <RadioListItemsWithAmountShowroom />
-      <H2 style={{ marginVertical: 16 }}>Switch</H2>
+      <H2 color={theme["textBody-default"]} style={{ marginVertical: 16 }}>
+        Switch
+      </H2>
       {/* Native Switch */}
       <NativeSwitchShowroom />
       {/* ListItemSwitch */}

--- a/src/components/checkbox/CheckboxLabel.tsx
+++ b/src/components/checkbox/CheckboxLabel.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useState } from "react";
 import { Pressable, View } from "react-native";
+import { useIOTheme } from "../../core";
 import { IOStyles } from "../../core/IOStyles";
 import { triggerHaptic } from "../../functions/haptic-feedback/hapticFeedback";
 import { HSpacer } from "../spacer/Spacer";
@@ -34,6 +35,8 @@ export const CheckboxLabel = ({
   disabled,
   onValueChange
 }: OwnProps) => {
+  const theme = useIOTheme();
+
   const [toggleValue, setToggleValue] = useState(checked ?? false);
 
   const toggleCheckbox = () => {
@@ -67,7 +70,7 @@ export const CheckboxLabel = ({
           <AnimatedCheckbox checked={checked ?? toggleValue} />
         </View>
         <HSpacer size={8} />
-        <H6 style={{ flexShrink: 1 }} color={"black"}>
+        <H6 style={{ flexShrink: 1 }} color={theme["textBody-default"]}>
           {label}
         </H6>
       </View>

--- a/src/components/layout/HeaderFirstLevel.tsx
+++ b/src/components/layout/HeaderFirstLevel.tsx
@@ -1,16 +1,16 @@
 import * as React from "react";
 import {
-  View,
-  StyleSheet,
   AccessibilityInfo,
+  StyleSheet,
+  View,
   findNodeHandle
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { IOColors, IOStyles, IOVisualCostants, useIOTheme } from "../../core";
 import { WithTestID } from "../../utils/types";
-import { IOStyles, IOVisualCostants, IOColors } from "../../core";
-import { H3 } from "../typography";
-import { HSpacer } from "../spacer";
 import { IconButton } from "../buttons";
+import { HSpacer } from "../spacer";
+import { H3 } from "../typography";
 import { ActionProp } from "./common";
 
 type CommonProps = WithTestID<{
@@ -49,7 +49,6 @@ interface ThreeActions extends CommonProps {
 
 export type HeaderFirstLevel = Base | OneAction | TwoActions | ThreeActions;
 
-const HEADER_BG_COLOR_LIGHT: IOColors = "white";
 const HEADER_BG_COLOR_DARK: IOColors = "bluegrey";
 
 const styles = StyleSheet.create({
@@ -73,6 +72,8 @@ export const HeaderFirstLevel = ({
   thirdAction
 }: HeaderFirstLevel) => {
   const titleRef = React.createRef<View>();
+  const insets = useSafeAreaInsets();
+  const theme = useIOTheme();
 
   React.useLayoutEffect(() => {
     const reactNode = findNodeHandle(titleRef.current);
@@ -80,7 +81,6 @@ export const HeaderFirstLevel = ({
       AccessibilityInfo.setAccessibilityFocus(reactNode);
     }
   });
-  const insets = useSafeAreaInsets();
 
   return (
     <View
@@ -88,7 +88,7 @@ export const HeaderFirstLevel = ({
         paddingTop: insets.top,
         backgroundColor:
           backgroundColor === "light"
-            ? IOColors[HEADER_BG_COLOR_LIGHT]
+            ? IOColors[theme["appBackground-primary"]]
             : IOColors[HEADER_BG_COLOR_DARK]
       }}
       accessibilityRole="header"
@@ -99,7 +99,9 @@ export const HeaderFirstLevel = ({
           <H3
             style={{ flexShrink: 1 }}
             numberOfLines={1}
-            color={backgroundColor === "dark" ? "white" : "black"}
+            color={
+              backgroundColor === "dark" ? "white" : theme["textBody-default"]
+            }
           >
             {title}
           </H3>

--- a/src/components/listitems/ListItemCheckbox.tsx
+++ b/src/components/listitems/ListItemCheckbox.tsx
@@ -21,10 +21,10 @@ import {
   hexToRgba,
   useIOTheme
 } from "../../core";
+import { AnimatedCheckbox } from "../checkbox/AnimatedCheckbox";
 import { IOIcons, Icon } from "../icons";
 import { HSpacer, VSpacer } from "../spacer";
 import { H6, LabelSmall } from "../typography";
-import { AnimatedCheckbox } from "../checkbox/AnimatedCheckbox";
 
 type Props = {
   value: string;
@@ -164,7 +164,7 @@ export const ListItemCheckbox = ({
                   />
                 </View>
               )}
-              <H6 color={"black"} style={{ flexShrink: 1 }}>
+              <H6 color={theme["textBody-default"]} style={{ flexShrink: 1 }}>
                 {value}
               </H6>
             </View>

--- a/src/components/listitems/ListItemRadio.tsx
+++ b/src/components/listitems/ListItemRadio.tsx
@@ -24,10 +24,10 @@ import {
 } from "../../core";
 import { WithTestID } from "../../utils/types";
 import { IOIcons, Icon } from "../icons";
+import { IOLogoPaymentType, LogoPayment } from "../logos";
+import { AnimatedRadio } from "../radio/AnimatedRadio";
 import { HSpacer, VSpacer } from "../spacer";
 import { H6, LabelSmall } from "../typography";
-import { AnimatedRadio } from "../radio/AnimatedRadio";
-import { IOLogoPaymentType, LogoPayment } from "../logos";
 
 type ListItemRadioGraphicProps =
   | { icon?: never; paymentLogo: IOLogoPaymentType }
@@ -246,7 +246,7 @@ export const ListItemRadio = ({
                 </View>
               )}
 
-              <H6 color={"black"} style={{ flexShrink: 1 }}>
+              <H6 color={theme["textBody-default"]} style={{ flexShrink: 1 }}>
                 {value}
               </H6>
             </View>

--- a/src/components/listitems/ListItemRadioWithAmount.tsx
+++ b/src/components/listitems/ListItemRadioWithAmount.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { StyleSheet, View } from "react-native";
 import RNReactNativeHapticFeedback from "react-native-haptic-feedback";
-import { IOColors, useIOExperimentalDesign } from "../../core";
+import { IOColors, useIOTheme } from "../../core";
 import { Icon } from "../icons";
 import { AnimatedRadio } from "../radio/AnimatedRadio";
 import { HSpacer, VSpacer } from "../spacer";
@@ -34,15 +34,16 @@ export const ListItemRadioWithAmount = (
       props.onValueChange(!toggleValue);
     }
   };
-  const { isExperimental } = useIOExperimentalDesign();
+  const theme = useIOTheme();
 
-  const interactiveColor: IOColors = isExperimental ? "blueIO-500" : "blue";
   const suggestColor: IOColors = "hanPurple-500";
 
   return (
     <PressableListItemBase onPress={pressHandler}>
       <View>
-        <LabelSmallAlt>{props.label}</LabelSmallAlt>
+        <LabelSmallAlt color={theme["textBody-default"]}>
+          {props.label}
+        </LabelSmallAlt>
         {props.isSuggested && (
           <>
             <VSpacer size={4} />
@@ -57,7 +58,9 @@ export const ListItemRadioWithAmount = (
         )}
       </View>
       <View pointerEvents="none" style={{ flexDirection: "row" }}>
-        <H6 color={interactiveColor}>{props.formattedAmountString}</H6>
+        <H6 color={theme["interactiveElem-default"]}>
+          {props.formattedAmountString}
+        </H6>
         <HSpacer size={8} />
         <AnimatedRadio checked={props.selected ?? toggleValue} />
       </View>

--- a/src/components/listitems/ListItemSwitch.tsx
+++ b/src/components/listitems/ListItemSwitch.tsx
@@ -1,19 +1,17 @@
 import React, { useMemo } from "react";
-import { GestureResponderEvent, Switch, View } from "react-native";
+import { GestureResponderEvent, Platform, Switch, View } from "react-native";
 import {
-  IOColors,
   IOSelectionListItemStyles,
   IOSelectionListItemVisualParams,
-  useIOExperimentalDesign,
   useIOTheme
 } from "../../core";
-import { IOIcons, Icon } from "../icons";
-import { HSpacer, VSpacer } from "../spacer";
-import { H6, LabelSmall, LabelLink } from "../typography";
-import { NativeSwitch } from "../switch/NativeSwitch";
 import { Badge } from "../badge";
-import { IOLogoPaymentType, LogoPayment } from "../logos";
+import { IOIcons, Icon } from "../icons";
 import { LoadingSpinner } from "../loadingSpinner";
+import { IOLogoPaymentType, LogoPayment } from "../logos";
+import { HSpacer, VSpacer } from "../spacer";
+import { NativeSwitch } from "../switch/NativeSwitch";
+import { H6, LabelLink, LabelSmall } from "../typography";
 
 type PartialProps = {
   label: string;
@@ -57,7 +55,6 @@ export const ListItemSwitch = React.memo(
     badge,
     onSwitchValueChange
   }: ListItemSwitchProps) => {
-    const { isExperimental } = useIOExperimentalDesign();
     const theme = useIOTheme();
 
     // If we have a badge or we are loading, we can't render the switch
@@ -66,8 +63,6 @@ export const ListItemSwitch = React.memo(
       () => !isLoading && !badge,
       [isLoading, badge]
     );
-
-    const primaryColor: IOColors = isExperimental ? "blueIO-500" : "blue";
 
     return (
       <View
@@ -96,9 +91,13 @@ export const ListItemSwitch = React.memo(
               alignItems: "center"
             }}
             accessible={!canRenderSwitch}
-            importantForAccessibility={
-              !canRenderSwitch ? "yes" : "no-hide-descendants"
-            }
+            {...Platform.select({
+              android: {
+                importantForAccessibility: !canRenderSwitch
+                  ? "yes"
+                  : "no-hide-descendants"
+              }
+            })}
           >
             {icon && (
               <View
@@ -129,12 +128,16 @@ export const ListItemSwitch = React.memo(
             )}
 
             <H6
-              color={"black"}
+              color={theme["textBody-default"]}
               style={{ flex: 1 }}
               accessible={!canRenderSwitch}
-              importantForAccessibility={
-                !canRenderSwitch ? "yes" : "no-hide-descendants"
-              }
+              {...Platform.select({
+                android: {
+                  importantForAccessibility: !canRenderSwitch
+                    ? "yes"
+                    : "no-hide-descendants"
+                }
+              })}
             >
               {label}
             </H6>
@@ -154,7 +157,12 @@ export const ListItemSwitch = React.memo(
                 testID={badge.testID}
               />
             )}
-            {isLoading && <LoadingSpinner size={24} color={primaryColor} />}
+            {isLoading && (
+              <LoadingSpinner
+                size={24}
+                color={theme["interactiveElem-default"]}
+              />
+            )}
             {canRenderSwitch && (
               <NativeSwitch
                 value={value}

--- a/src/components/listitems/ListItemSwitch.tsx
+++ b/src/components/listitems/ListItemSwitch.tsx
@@ -131,13 +131,9 @@ export const ListItemSwitch = React.memo(
               color={theme["textBody-default"]}
               style={{ flex: 1 }}
               accessible={!canRenderSwitch}
-              {...Platform.select({
-                android: {
-                  importantForAccessibility: !canRenderSwitch
-                    ? "yes"
-                    : "no-hide-descendants"
-                }
-              })}
+              importantForAccessibility={
+                !canRenderSwitch ? "yes" : "no-hide-descendants"
+              }
             >
               {label}
             </H6>

--- a/src/components/listitems/__test__/__snapshots__/listitem.test.tsx.snap
+++ b/src/components/listitems/__test__/__snapshots__/listitem.test.tsx.snap
@@ -2848,7 +2848,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 1`] = `
       >
         <Text
           allowFontScaling={false}
-          color="blue"
+          color="blueIO-500"
           defaultColor="black"
           defaultWeight="SemiBold"
           font="TitilliumWeb"
@@ -2865,7 +2865,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 1`] = `
                 "lineHeight": 25,
               },
               {
-                "color": "#0073E6",
+                "color": "#0B3EE3",
                 "fontFamily": "Titillium Web",
                 "fontStyle": "normal",
                 "fontWeight": "600",
@@ -3128,7 +3128,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 2`] = `
       >
         <Text
           allowFontScaling={false}
-          color="blue"
+          color="blueIO-500"
           defaultColor="black"
           defaultWeight="SemiBold"
           font="TitilliumWeb"
@@ -3145,7 +3145,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 2`] = `
                 "lineHeight": 25,
               },
               {
-                "color": "#0073E6",
+                "color": "#0B3EE3",
                 "fontFamily": "Titillium Web",
                 "fontStyle": "normal",
                 "fontWeight": "600",

--- a/src/components/radio/RadioButtonLabel.tsx
+++ b/src/components/radio/RadioButtonLabel.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useState } from "react";
 import { Pressable, View } from "react-native";
+import { useIOTheme } from "../../core";
 import { IOStyles } from "../../core/IOStyles";
 import { triggerHaptic } from "../../functions/haptic-feedback/hapticFeedback";
 import { HSpacer } from "../spacer/Spacer";
@@ -34,6 +35,8 @@ export const RadioButtonLabel = ({
   disabled,
   onValueChange
 }: OwnProps) => {
+  const theme = useIOTheme();
+
   const [toggleValue, setToggleValue] = useState(checked ?? false);
 
   const toggleRadioButton = () => {
@@ -64,7 +67,7 @@ export const RadioButtonLabel = ({
           <AnimatedRadio checked={checked ?? toggleValue} />
         </View>
         <HSpacer size={8} />
-        <H6 style={{ flexShrink: 1 }} color={"black"}>
+        <H6 style={{ flexShrink: 1 }} color={theme["textBody-default"]}>
           {label}
         </H6>
       </View>

--- a/src/components/switch/SwitchLabel.tsx
+++ b/src/components/switch/SwitchLabel.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useState } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
-import { IOColors, useIOExperimentalDesign } from "../../core";
+import { IOColors, useIOExperimentalDesign, useIOTheme } from "../../core";
 import { IOStyles } from "../../core/IOStyles";
 import { triggerHaptic } from "../../functions/haptic-feedback/hapticFeedback";
 import { makeFontStyleObject } from "../../utils/fonts";
@@ -48,10 +48,11 @@ export const SwitchLabel = ({
   onValueChange
 }: OwnProps) => {
   const [toggleValue, setToggleValue] = useState(checked ?? false);
+  const theme = useIOTheme();
 
   const { isExperimental } = useIOExperimentalDesign();
   const switchLabelText = (
-    <H6 style={{ flexShrink: 1 }} color={"black"}>
+    <H6 style={{ flexShrink: 1 }} color={theme["textBody-default"]}>
       {label}
     </H6>
   );


### PR DESCRIPTION
## Short description
This PR makes *Selection* components dark mode compatible.

## List of changes proposed in this pull request
- Add theme values to various `Radio`, `Checkbox` and `Switch` components
- Make `HeaderFirstLevel` dark mode compatible

### Preview
<img src="https://github.com/pagopa/io-app-design-system/assets/1255491/13082aa0-8717-4068-8163-7893f7297926" width="360" />

## How to test
1. Launch the example app
2. Go to the *Selection* page, enable/disable dark mode