### PR TITLE
fix: header accessibility on empty title should avoid autofocus

### DIFF
--- a/example/src/pages/StaticHeaderSecondLevel.tsx
+++ b/example/src/pages/StaticHeaderSecondLevel.tsx
@@ -41,7 +41,7 @@ export const StaticHeaderSecondLevelScreen = () => {
     navigation.setOptions({
       header: () => (
         <HeaderSecondLevel
-          title={"Questo è un titolo statico"}
+          title=""
           goBack={() => navigation.goBack()}
           backAccessibilityLabel="Torna indietro"
           type="singleAction"

--- a/src/components/layout/HeaderSecondLevel.tsx
+++ b/src/components/layout/HeaderSecondLevel.tsx
@@ -134,11 +134,14 @@ export const HeaderSecondLevel = ({
 
   const { isExperimental } = useIOExperimentalDesign();
   const insets = useSafeAreaInsets();
+  const isTitleAccessible = React.useMemo(() => !!title.trim(), [title]);
 
   React.useLayoutEffect(() => {
-    const reactNode = findNodeHandle(titleRef.current);
-    if (reactNode !== null) {
-      AccessibilityInfo.setAccessibilityFocus(reactNode);
+    if (isTitleAccessible) {
+      const reactNode = findNodeHandle(titleRef.current);
+      if (reactNode !== null) {
+        AccessibilityInfo.setAccessibilityFocus(reactNode);
+      }
     }
   });
 
@@ -160,7 +163,6 @@ export const HeaderSecondLevel = ({
       : "transparent"
   }));
 
-  const isTitleAccessible = !!title.trim();
   const titleAnimatedStyle = useAnimatedStyle(() => ({
     opacity: scrollValues
       ? interpolate(

--- a/src/components/layout/HeaderSecondLevel.tsx
+++ b/src/components/layout/HeaderSecondLevel.tsx
@@ -201,6 +201,10 @@ export const HeaderSecondLevel = ({
         )}
         <View
           ref={titleRef}
+          accessibilityElementsHidden={!isTitleAccessible}
+          importantForAccessibility={
+            isTitleAccessible ? "yes" : "no-hide-descendants"
+          }
           accessible={isTitleAccessible}
           accessibilityLabel={title}
           accessibilityRole="header"


### PR DESCRIPTION
## Short description
This PR prevents accessibility focus on empty header title

## List of changes proposed in this pull request
- HeaderSecondLevel accessibility props


## How to test
Test accessibility on real device to check TB/VO behaviour