### PR TITLE
[IOBP-576] TextInputBase autoFocus prop

### DIFF
--- a/example/src/pages/TextInputs.tsx
+++ b/example/src/pages/TextInputs.tsx
@@ -81,6 +81,12 @@ export const TextInputs = () => (
     >
       <H4>Base input</H4>
       <InputComponentWrapper placeholder={"Base input"} />
+      <H5>Base input with autofocus</H5>
+      <InputComponentWrapper
+        placeholder={"Focused base input"}
+        bottomMessage="A normal input, but it focuses on page open!"
+        autoFocus
+      />
       <H5>Base input with value formatted</H5>
       <InputComponentWrapper
         placeholder={"Base input"}

--- a/src/components/textInput/TextInputBase.tsx
+++ b/src/components/textInput/TextInputBase.tsx
@@ -45,6 +45,7 @@ type InputTextProps = WithTestID<{
   isPassword?: boolean;
   onBlur?: () => void;
   onFocus?: () => void;
+  autoFocus?: boolean;
 }>;
 
 const inputMarginTop: IOSpacingScale = 8;
@@ -157,7 +158,8 @@ export const TextInputBase = ({
   bottomMessageColor,
   onBlur,
   onFocus,
-  isPassword
+  isPassword,
+  autoFocus
 }: InputTextProps) => {
   const labelSharedValue = useSharedValue<boolean>(false);
   const [inputStatus, setInputStatus] = React.useState<InputStatus>(
@@ -302,6 +304,7 @@ export const TextInputBase = ({
               ? styles.textInputStyleFont
               : styles.textInputStyleLegacyFont
           ]}
+          autoFocus={autoFocus}
         />
         {/** Left value is due to the absolute position of the label in order to let it
          * translate to top on focus


### PR DESCRIPTION
## Short description
added `autoFocus` prop to `TextInputBase` in order to be able to focus any text input on first render
<img width="250" alt="Screenshot 2024-03-19 at 11 57 09" src="https://github.com/pagopa/io-app-design-system/assets/60693085/501a4091-ef5f-419e-88b1-36320d757697">

## List of changes proposed in this pull request
- added prop
- added example app entry

## How to test
in the example app, navigate to the text inputs section and make sure the second input has been automatically focused
