### PR TITLE
[IOAPPX-267] Add a11y props to `LogoPaymentCard`

### DIFF
--- a/example/src/pages/Logos.tsx
+++ b/example/src/pages/Logos.tsx
@@ -237,9 +237,11 @@ const renderPaymentLogosCard = () => (
         size="full"
         image={
           <LogoPaymentCard
+            accessibilityLabel={logoItemName}
             align="start"
             height={32}
             name={logoItemName as IOLogoPaymentCardType}
+            testID={`${logoItemName}-testID`}
           />
         }
       />
@@ -258,11 +260,29 @@ const renderPaymentLogosCard = () => (
           borderWidth: 1
         }}
       >
-        <LogoPaymentCard debugMode height={32} name="payPal" align="start" />
+        <LogoPaymentCard
+          debugMode
+          height={32}
+          name="payPal"
+          accessibilityLabel="PayPal"
+          align="start"
+        />
         <VSpacer size={8} />
-        <LogoPaymentCard debugMode height={32} name="payPal" align="center" />
+        <LogoPaymentCard
+          debugMode
+          height={32}
+          name="payPal"
+          accessibilityLabel="PayPal"
+          align="center"
+        />
         <VSpacer size={8} />
-        <LogoPaymentCard debugMode height={32} name="payPal" align="end" />
+        <LogoPaymentCard
+          debugMode
+          height={32}
+          name="payPal"
+          accessibilityLabel="PayPal"
+          align="end"
+        />
       </View>
     </ComponentViewerBox>
   </View>

--- a/src/components/logos/LogoPaymentCard.tsx
+++ b/src/components/logos/LogoPaymentCard.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { View, StyleSheet } from "react-native";
-import { hexToRgba, IOColors } from "../../core";
+import { StyleSheet, View } from "react-native";
+import { WithTestID } from "src/utils/types";
+import { IOColors, hexToRgba } from "../../core";
 
 /* Logos */
-import LogoPaymentCardPayPal from "./svg/LogoPaymentCardPayPal";
 import LogoPaymentCardBancomatPay from "./svg/LogoPaymentCardBancomatPay";
+import LogoPaymentCardPayPal from "./svg/LogoPaymentCardPayPal";
 import { SVGCardLogoProps } from "./types";
 
 export const IOPaymentCardLogos = {
@@ -14,13 +15,14 @@ export const IOPaymentCardLogos = {
 
 export type IOLogoPaymentCardType = keyof typeof IOPaymentCardLogos;
 
-type IOPaymentLogos = {
+type IOPaymentLogos = WithTestID<{
   name: IOLogoPaymentCardType;
+  accessibilityLabel: string;
   align: "start" | "center" | "end";
   width?: "100%" | number;
   height?: number;
   debugMode?: boolean;
-};
+}>;
 
 const preserveAspectRatioValues: Record<
   IOPaymentLogos["align"],
@@ -42,12 +44,19 @@ const LogoPaymentCard = ({
   width = "100%",
   height = 32,
   align = "center",
+  accessibilityLabel,
+  testID,
   debugMode = false,
   ...props
 }: IOPaymentLogos) => {
   const LogoElement = IOPaymentCardLogos[name];
   return (
-    <View style={[{ width, height }, debugMode && styles.debugMode]}>
+    <View
+      accessible={true}
+      accessibilityLabel={accessibilityLabel}
+      style={[{ width, height }, debugMode && styles.debugMode]}
+      testID={testID}
+    >
       <LogoElement
         preserveAspectRatio={preserveAspectRatioValues[align]}
         {...props}

--- a/stories/foundation/logos/LogoPaymentCard.stories.ts
+++ b/stories/foundation/logos/LogoPaymentCard.stories.ts
@@ -21,6 +21,7 @@ type Story = StoryObj<typeof meta>;
 export const Primary: Story = {
   args: {
     name: "payPal",
+    accessibilityLabel: "PayPal",
     align: "center",
     width: 100,
     height: 32,


### PR DESCRIPTION
## Short description
This PR adds _a11y_ props to `LogoPaymentCard` in order to be used in the new `PaymentCard` component.

## List of changes proposed in this pull request
- Add mandatory `accessibilityLabel` prop
- Make the component always accessible
- Add optional `testID` prop
- Update relative Story

### Preview
<img src="https://github.com/pagopa/io-app-design-system/assets/1255491/5499d023-29d3-44b9-8c5e-0495df536b9a" width="320" />

## How to test
N/A