### PR TITLE
[IOAPPX-269] Fix wrong color of TextInput when experimental DS is off

### DIFF
--- a/src/components/textInput/TextInputBase.tsx
+++ b/src/components/textInput/TextInputBase.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-native";
 import Animated, {
   Easing,
+  WithTimingConfig,
   useAnimatedStyle,
   useSharedValue,
   withTiming
@@ -17,7 +18,8 @@ import {
   IOColors,
   IOSpacingScale,
   IOStyles,
-  useIOExperimentalDesign
+  useIOExperimentalDesign,
+  useIOTheme
 } from "../../core";
 import { makeFontStyleObject } from "../../utils/fonts";
 import { RNTextInputProps, getInputPropsByType } from "../../utils/textInput";
@@ -161,6 +163,8 @@ export const TextInputBase = ({
   isPassword,
   autoFocus
 }: InputTextProps) => {
+  const theme = useIOTheme();
+
   const labelSharedValue = useSharedValue<boolean>(false);
   const [inputStatus, setInputStatus] = React.useState<InputStatus>(
     disabled ? "disabled" : "initial"
@@ -177,7 +181,7 @@ export const TextInputBase = ({
   const boxStyle: ViewStyle = useMemo(() => {
     if (inputStatus === "focused") {
       return {
-        borderColor: IOColors["blueIO-500"],
+        borderColor: IOColors[theme["interactiveElem-default"]],
         borderWidth: 2
       };
     }
@@ -191,20 +195,17 @@ export const TextInputBase = ({
       borderColor: IOColors["grey-200"],
       borderWidth: 1
     };
-  }, [inputStatus]);
+  }, [inputStatus, theme]);
+
+  const easingConf: WithTimingConfig = {
+    duration: 300,
+    easing: Easing.elastic(0.85)
+  };
 
   const animatedLabelProps = useAnimatedStyle(() => ({
-    fontSize: withTiming(labelSharedValue.value ? 12 : 16, {
-      duration: 300,
-      easing: Easing.elastic(0.85)
-    }),
+    fontSize: withTiming(labelSharedValue.value ? 12 : 16, easingConf),
     transform: [
-      {
-        translateY: withTiming(labelSharedValue.value ? -14 : 0, {
-          duration: 300,
-          easing: Easing.elastic(0.85)
-        })
-      }
+      { translateY: withTiming(labelSharedValue.value ? -14 : 0, easingConf) }
     ]
   }));
 
@@ -294,6 +295,8 @@ export const TextInputBase = ({
             labelSharedValue.value = true;
             onFocus?.();
           }}
+          selectionColor={IOColors[theme["interactiveElem-default"]]} // Caret iOS
+          cursorColor={IOColors[theme["interactiveElem-default"]]} // Caret Android
           maxLength={counterLimit}
           onBlur={onBlurHandler}
           value={inputValue}


### PR DESCRIPTION
## Short description
This PR fixes the wrong color of `TextFields` components when the experimental DS is disabled.

## List of changes proposed in this pull request
- Add the correct theme key value to the border
- Change caret color on both iOS and Android

### Preview
| New DS off | New DS on |
|--------|--------|
| ![Simulator Screenshot - iPhone 14 Pro - 2024-03-27 at 10 07 20](https://github.com/pagopa/io-app-design-system/assets/1255491/2f4c4937-916d-406d-bdba-6b593ff01536) | ![Simulator Screenshot - iPhone 14 Pro - 2024-03-27 at 10 07 31](https://github.com/pagopa/io-app-design-system/assets/1255491/d5fe14c7-1584-4bbd-b2b3-0cf4712d469f) | 


## How to test
1. Launch the example app
2. Go to the **TextInputs** screen