### PR TITLE
fix: avatar component unused props

### DIFF
--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -17,16 +17,12 @@ import {
 import { addCacheTimestampToUri } from "../../utils/image";
 
 type Avatar = {
-  imageSource?:
-    | ImageRequireSource
-    | ImageURISource
-    | ReadonlyArray<ImageURISource>;
   /**
    * @deprecated Only `square` shape variant accepted
    */
   shape?: "circle" | "square";
   size: "small" | "medium";
-  logoUri?: ImageURISource | ReadonlyArray<ImageURISource>;
+  logoUri?: ImageRequireSource | ImageURISource | ReadonlyArray<ImageURISource>;
 };
 
 const internalSpaceDefaultSize: number = 6;
@@ -86,6 +82,8 @@ export const Avatar = ({ logoUri, size }: Avatar) => {
       ? undefined
       : Array.isArray(logoUri)
       ? addCacheTimestampToUri(logoUri[0])
+      : typeof logoUri === "number"
+      ? logoUri
       : addCacheTimestampToUri(logoUri as ImageURISource)
   );
 

--- a/stories/foundation/avatar/Avatar.stories.ts
+++ b/stories/foundation/avatar/Avatar.stories.ts
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { ImageURISource } from "react-native";
 import { Avatar } from "../../../src/components";
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
@@ -31,8 +30,9 @@ export const EnitityLogo: Story = {
   args: {
     shape: "circle",
     size: "medium",
-    logoUri:
-      "https://assets.cdn.io.italia.it/logos/organizations/80078750587.png" as ImageURISource
+    logoUri: {
+      uri: "https://assets.cdn.io.italia.it/logos/organizations/80078750587.png"
+    }
   }
 };
 
@@ -42,8 +42,10 @@ export const EnitityLogoWithFallback: Story = {
     shape: "circle",
     size: "medium",
     logoUri: [
-      "https://wrongUri.png",
-      "https://assets.cdn.io.italia.it/logos/organizations/80078750587.png"
-    ] as ReadonlyArray<ImageURISource>
+      { uri: "https://wrongUri.png" },
+      {
+        uri: "https://assets.cdn.io.italia.it/logos/organizations/80078750587.png"
+      }
+    ]
   }
 };


### PR DESCRIPTION
## Short description
This PR fixes a coding issue that would cause problem using Avatar component. 

`imageSource` prop was defined but actually unused, logoUri is the predefined one.

## List of changes proposed in this pull request
- Remove imageSource prop from Avatar.tsx

## How to test
Check avatar component to proper render
