### PR TITLE
[IOBP-600] Fix list item radio icon resize mode

### DIFF
--- a/example/src/pages/ListItem.tsx
+++ b/example/src/pages/ListItem.tsx
@@ -9,6 +9,7 @@ import {
   ListItemInfoCopy,
   ListItemNav,
   ListItemNavAlert,
+  ListItemRadio,
   ListItemRadioWithAmount,
   ListItemSwitch,
   ListItemTransaction,
@@ -99,6 +100,14 @@ export const ListItems = () => {
         ListItemTransaction
       </H2>
       {renderListItemTransaction()}
+      <H2
+        color={theme["textHeading-default"]}
+        weight={"SemiBold"}
+        style={{ marginBottom: 16, marginTop: 16 }}
+      >
+        ListItemRadio
+      </H2>
+      {renderListItemRadio()}
       <H2
         color={theme["textHeading-default"]}
         weight={"SemiBold"}
@@ -664,6 +673,33 @@ const renderListItemTransaction = () => (
         onPress={onButtonPress}
         transactionStatus="success"
       />
+    </View>
+  </ComponentViewerBox>
+);
+
+const renderListItemRadio = () => (
+  <ComponentViewerBox name="ListItemRadio">
+    <View>
+      <ListItemRadio value="Item (selected)" selected={true} />
+      <Divider />
+      <ListItemRadio value="Item" selected={false} />
+      <Divider />
+      <ListItemRadio
+        value="Item with square icon"
+        selected={false}
+        startImage={{
+          uri: "https://github.com/pagopa/io-services-metadata/blob/master/logos/apps/paypal.png?raw=true"
+        }}
+      />
+      <Divider />
+      <ListItemRadio
+        value="Item with rectangular icon"
+        selected={false}
+        startImage={{
+          uri: "https://raw.githubusercontent.com/slaterjohn/payment-logos/master/Rounded%20Corners/PNG/medium/visa.png?raw=true"
+        }}
+      />
+      <Divider />
     </View>
   </ComponentViewerBox>
 );

--- a/src/components/listitems/ListItemRadio.tsx
+++ b/src/components/listitems/ListItemRadio.tsx
@@ -68,7 +68,8 @@ type OwnProps = Props &
 const styles = StyleSheet.create({
   imageSize: {
     width: IOSelectionListItemVisualParams.iconSize,
-    height: IOSelectionListItemVisualParams.iconSize
+    height: IOSelectionListItemVisualParams.iconSize,
+    resizeMode: "contain"
   }
 });
 


### PR DESCRIPTION
## Short description
This PR fixes the aspect ratio for rectangular icons added to `ListItemRadio` components

## List of changes proposed in this pull request
- Added `resizeMode: "contain"` to `ListItemRadio` image
- Added examples

## How to test
Navigate to **List Items > ListItemRadio**, check that the `ListItemRadio` with a square icon is displayed correctly like in the preview below.

## Preview

<img width="250" alt="Screenshot 2024-03-29 alle 10 09 43" src="https://github.com/pagopa/io-app-design-system/assets/6160324/d4c78f34-cf5f-4f90-9d06-6efb8568dcdd">

