### PR TITLE
chore: add image prop to `ModuleCheckout` component

### DIFF
--- a/example/src/pages/Modules.tsx
+++ b/example/src/pages/Modules.tsx
@@ -117,6 +117,16 @@ const renderModuleCheckout = () => (
         onPress={modulePress}
       />
     </ComponentViewerBox>
+    <ComponentViewerBox name="ModuleCheckout, default, with image">
+      <ModuleCheckout
+        image={{
+          uri: "https://assets.cdn.platform.pagopa.it/apm/bancomatpay.png"
+        }}
+        title="Paga con Bancomat PAY"
+        ctaText="Modifica"
+        onPress={modulePress}
+      />
+    </ComponentViewerBox>
     <ComponentViewerBox name="ModuleCheckout, no description">
       <ModuleCheckout
         paymentLogo="amex"

--- a/src/components/modules/ModuleCheckout.tsx
+++ b/src/components/modules/ModuleCheckout.tsx
@@ -1,8 +1,15 @@
 import * as React from "react";
-import { StyleSheet, View } from "react-native";
+import {
+  Image,
+  ImageSourcePropType,
+  ImageURISource,
+  StyleSheet,
+  View
+} from "react-native";
 import Placeholder from "rn-placeholder";
 import {
   IOModuleStyles,
+  IOSelectionListItemVisualParams,
   IOSpacingScale,
   IOStyles,
   useIOTheme
@@ -13,31 +20,28 @@ import { HSpacer, VSpacer } from "../spacer";
 import { H6, LabelSmall } from "../typography";
 import { PressableModuleBase } from "./PressableModuleBase";
 
-// ---------------- types ----------------
-
-type ModuleCheckoutPartialProps =
-  | {
-      isLoading?: false;
-      paymentLogo?: IOLogoPaymentType;
-      title: string;
-      subtitle?: string;
-      onPress: () => void;
-    }
-  | {
-      isLoading: true;
-      paymentLogo?: never;
-      title?: never;
-      subtitle?: never;
-      onPress?: never;
-    };
-
-export type ModuleCheckoutProps = ModuleCheckoutPartialProps & {
+type LoadingProps = {
+  isLoading: true;
   ctaText?: string;
 };
 
-type ActionOnlyProps = { text?: string };
+type ImageProps =
+  | { paymentLogo: IOLogoPaymentType; image?: never }
+  | { paymentLogo?: never; image: ImageURISource | ImageSourcePropType }
+  | { paymentLogo?: never; image?: never };
 
-// ---------------- component ----------------
+type BaseProps = {
+  isLoading?: false;
+  paymentLogo?: IOLogoPaymentType;
+  title: string;
+  subtitle?: string;
+  ctaText?: string;
+  onPress: () => void;
+} & ImageProps;
+
+export type ModuleCheckoutProps = LoadingProps | BaseProps;
+
+type ActionOnlyProps = { text?: string };
 
 export const ModuleCheckout = (props: ModuleCheckoutProps) => {
   const theme = useIOTheme();
@@ -46,21 +50,29 @@ export const ModuleCheckout = (props: ModuleCheckoutProps) => {
     return <LoadingVersion text={props.ctaText} />;
   }
 
-  const paymentLogoEndMargin: IOSpacingScale = 12;
+  const { paymentLogo, image } = props;
 
-  const ModuleBaseContent = () => (
-    <View style={styles.rowCenter}>
-      {/*
-          we don't want to let the `space-between`
-          handle spacing for the logo/text section,
-          so we use a row and a marginEnd on the logo
-        */}
-      {props.paymentLogo && (
-        <View style={{ marginEnd: paymentLogoEndMargin }}>
-          <LogoPayment name={props.paymentLogo} />
+  const imageComponent = (
+    <>
+      {paymentLogo && (
+        <View style={styles.imageWrapper}>
+          <LogoPayment name={paymentLogo} />
         </View>
       )}
-      <View style={IOStyles.flex}>
+      {image && (
+        <Image
+          source={image}
+          style={[styles.imageWrapper, styles.image]}
+          accessibilityIgnoresInvertColors={true}
+        />
+      )}
+    </>
+  );
+
+  const ModuleBaseContent = () => (
+    <>
+      {imageComponent}
+      <View style={styles.content}>
         <H6>{props.title}</H6>
         {props.subtitle && (
           <LabelSmall weight="Regular" color={theme["textBody-tertiary"]}>
@@ -68,7 +80,7 @@ export const ModuleCheckout = (props: ModuleCheckoutProps) => {
           </LabelSmall>
         )}
       </View>
-    </View>
+    </>
   );
 
   if (props.ctaText) {
@@ -87,8 +99,6 @@ export const ModuleCheckout = (props: ModuleCheckoutProps) => {
   );
 };
 
-// ---------------- sub-components----------------
-
 const ModuleAction = ({ text }: ActionOnlyProps) => (
   <View pointerEvents="none">
     <ButtonLink
@@ -101,7 +111,7 @@ const ModuleAction = ({ text }: ActionOnlyProps) => (
 
 const LoadingVersion = ({ text }: ActionOnlyProps) => (
   <View style={IOModuleStyles.button}>
-    <View style={styles.rowCenter}>
+    <View style={[IOStyles.row, IOStyles.alignCenter]}>
       <Placeholder.Box animate="fade" radius={8} height={24} width={24} />
       <HSpacer size={8} />
       <View>
@@ -114,12 +124,19 @@ const LoadingVersion = ({ text }: ActionOnlyProps) => (
   </View>
 );
 
-// ---------------- styles ----------------
+const imageMarginRight: IOSpacingScale = 12;
 
 const styles = StyleSheet.create({
-  rowCenter: {
-    flexDirection: "row",
-    alignItems: "center",
-    flex: 1
+  imageWrapper: {
+    marginRight: imageMarginRight
+  },
+  image: {
+    width: IOSelectionListItemVisualParams.iconSize,
+    height: IOSelectionListItemVisualParams.iconSize,
+    resizeMode: "contain"
+  },
+  content: {
+    flexGrow: 1,
+    flexShrink: 1
   }
 });

--- a/src/components/modules/ModuleCheckout.tsx
+++ b/src/components/modules/ModuleCheckout.tsx
@@ -41,13 +41,11 @@ type BaseProps = {
 
 export type ModuleCheckoutProps = LoadingProps | BaseProps;
 
-type ActionOnlyProps = { text?: string };
-
 export const ModuleCheckout = (props: ModuleCheckoutProps) => {
   const theme = useIOTheme();
 
   if (props.isLoading) {
-    return <LoadingVersion text={props.ctaText} />;
+    return <LoadingVersion {...props} />;
   }
 
   const { paymentLogo, image } = props;
@@ -87,7 +85,7 @@ export const ModuleCheckout = (props: ModuleCheckoutProps) => {
     return (
       <PressableModuleBase onPress={props.onPress}>
         <ModuleBaseContent />
-        {props.ctaText && <ModuleAction text={props.ctaText} />}
+        {props.ctaText && <ModuleAction ctaText={props.ctaText} />}
       </PressableModuleBase>
     );
   }
@@ -99,17 +97,17 @@ export const ModuleCheckout = (props: ModuleCheckoutProps) => {
   );
 };
 
-const ModuleAction = ({ text }: ActionOnlyProps) => (
+const ModuleAction = ({ ctaText }: Pick<ModuleCheckoutProps, "ctaText">) => (
   <View pointerEvents="none">
     <ButtonLink
-      label={text ?? ""}
-      accessibilityLabel={text}
+      label={ctaText ?? ""}
+      accessibilityLabel={ctaText}
       onPress={() => null}
     />
   </View>
 );
 
-const LoadingVersion = ({ text }: ActionOnlyProps) => (
+const LoadingVersion = ({ ctaText }: LoadingProps) => (
   <View style={IOModuleStyles.button}>
     <View style={[IOStyles.row, IOStyles.alignCenter]}>
       <Placeholder.Box animate="fade" radius={8} height={24} width={24} />
@@ -120,7 +118,7 @@ const LoadingVersion = ({ text }: ActionOnlyProps) => (
         <Placeholder.Box animate="fade" radius={8} height={16} width={116} />
       </View>
     </View>
-    <ModuleAction text={text} />
+    <ModuleAction ctaText={ctaText} />
   </View>
 );
 


### PR DESCRIPTION
## Short description
This PR adds the ability to use an external image as icon in the `ModuleCheckout` component

## List of changes proposed in this pull request
- Refactored `ModuleCheckoutProps`
- Added ability to pass an external URI (or internal asset) as image to `ModuleCheckout` component

## How to test
Launch the example app and check the **Module** section. Component should render as the preview belo

## Preview
<img width="300" alt="Screenshot 2024-04-15 alle 12 24 01" src="https://github.com/pagopa/io-app-design-system/assets/6160324/72b266cf-de1d-4b6e-94b6-7079f8ed1eb6">


