### PR TITLE
[chore] Add optional `testID` property to `ListItemSwitch`

### DIFF
--- a/src/components/listitems/ListItemSwitch.tsx
+++ b/src/components/listitems/ListItemSwitch.tsx
@@ -20,6 +20,7 @@ type PartialProps = {
   action?: SwitchAction;
   isLoading?: boolean;
   badge?: Badge;
+  testID?: string;
 };
 
 export type SwitchAction = {
@@ -53,7 +54,8 @@ export const ListItemSwitch = React.memo(
     action,
     isLoading,
     badge,
-    onSwitchValueChange
+    onSwitchValueChange,
+    testID
   }: ListItemSwitchProps) => {
     const theme = useIOTheme();
 
@@ -66,7 +68,7 @@ export const ListItemSwitch = React.memo(
 
     return (
       <View
-        testID="ListItemSwitch"
+        testID={testID ?? "ListItemSwitch"}
         style={[
           IOSelectionListItemStyles.listItem,
           {

--- a/src/components/listitems/ListItemSwitch.tsx
+++ b/src/components/listitems/ListItemSwitch.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import { GestureResponderEvent, Platform, Switch, View } from "react-native";
+import { WithTestID } from "src/utils/types";
 import {
   IOSelectionListItemStyles,
   IOSelectionListItemVisualParams,
@@ -13,15 +14,14 @@ import { HSpacer, VSpacer } from "../spacer";
 import { NativeSwitch } from "../switch/NativeSwitch";
 import { H6, LabelLink, LabelSmall } from "../typography";
 
-type PartialProps = {
+type PartialProps = WithTestID<{
   label: string;
   onSwitchValueChange?: (newValue: boolean) => void;
   description?: string;
   action?: SwitchAction;
   isLoading?: boolean;
   badge?: Badge;
-  testID?: string;
-};
+}>;
 
 export type SwitchAction = {
   label: string;


### PR DESCRIPTION
## Short description
This PR adds the optional property testID to ListItemSwitch.

## List of changes proposed in this pull request
- ListItemSwitch’s props have the testID property
- ListItemSwitch’s main view uses the provided testID property, if defined, or fallback to default one

