### PR TITLE
chore: [PE-594] Remove marginLeft from `ListItemNav` chevron icon

### DIFF
--- a/src/components/listitems/ListItemNav.tsx
+++ b/src/components/listitems/ListItemNav.tsx
@@ -268,7 +268,7 @@ export const ListItemNav = ({
           <View style={IOStyles.flex}>{listItemNavContent}</View>
           {loading && <LoadingSpinner color={primaryColor} />}
           {!loading && !hideChevron && (
-            <View style={{ marginLeft: IOListItemVisualParams.iconMargin }}>
+            <View>
               <Icon
                 name="chevronRightListItem"
                 color={navIconColor}

--- a/src/components/listitems/ListItemNav.tsx
+++ b/src/components/listitems/ListItemNav.tsx
@@ -268,13 +268,11 @@ export const ListItemNav = ({
           <View style={IOStyles.flex}>{listItemNavContent}</View>
           {loading && <LoadingSpinner color={primaryColor} />}
           {!loading && !hideChevron && (
-            <View>
-              <Icon
-                name="chevronRightListItem"
-                color={navIconColor}
-                size={IOListItemVisualParams.chevronSize}
-              />
-            </View>
+            <Icon
+              name="chevronRightListItem"
+              color={navIconColor}
+              size={IOListItemVisualParams.chevronSize}
+            />
           )}
         </Animated.View>
       </Animated.View>


### PR DESCRIPTION
## Short description
This PR removes the static marginLeft from the `ListItemNav` chevron icon

## List of changes proposed in this pull request
- Removed the `View` that wraps the chevron icon removing the additional marginLeft


