### PR TITLE
chore: [IOBP-641] Add `ListItemHeader` a11y role as heading

### DIFF
--- a/src/components/listitems/ListItemHeader.tsx
+++ b/src/components/listitems/ListItemHeader.tsx
@@ -79,7 +79,7 @@ export const ListItemHeader = ({
           endElement !== undefined && endElement.type !== "badge"
         }
       >
-        <H6 weight="Regular" color={theme["textBody-tertiary"]}>
+        <H6 role="heading" weight="Regular" color={theme["textBody-tertiary"]}>
           {label}
         </H6>
       </View>


### PR DESCRIPTION
## Short description
This PR adds the header role to the label of the `ListItemHeader` component.

## List of changes proposed in this pull request
- Added `role` attribute to the `H6` component that wraps the label

## How to test
With the voice over active, you should be able to hear the heading role while tapping on it.