### PR TITLE
chore: [IOBP-654] Add paymentLogoIcon attribute to the `ListItemInfo`

### DIFF
--- a/example/src/pages/ListItem.tsx
+++ b/example/src/pages/ListItem.tsx
@@ -451,6 +451,12 @@ const renderListItemInfo = () => (
         icon="gallery"
         accessibilityLabel="Empty just for testing purposes"
       />
+      <ListItemInfo
+        label="Label"
+        value={"Value"}
+        paymentLogoIcon="payPal"
+        accessibilityLabel="Empty just for testing purposes"
+      />
     </View>
   </ComponentViewerBox>
 );

--- a/src/components/listitems/ListItemInfo.tsx
+++ b/src/components/listitems/ListItemInfo.tsx
@@ -7,10 +7,12 @@ import {
   useIOTheme
 } from "../../core";
 import { WithTestID } from "../../utils/types";
-import { IOIcons, Icon } from "../icons";
+import { IOIconSizeScale, IOIcons, Icon } from "../icons";
 import { H6, LabelSmall } from "../typography";
 import { ButtonLink, IconButton } from "../buttons";
 import { Badge } from "../badge";
+import { LogoPaymentWithFallback } from "../common/LogoPaymentWithFallback";
+import { IOLogoPaymentType } from "../logos";
 
 type ButtonLinkActionProps = {
   type: "buttonLink";
@@ -36,17 +38,29 @@ export type ListItemInfo = WithTestID<{
   label: string;
   value: string | React.ReactNode;
   numberOfLines?: number;
-  icon?: IOIcons;
   endElement?: EndElementProps;
   // Accessibility
   accessibilityLabel?: string;
-}>;
+}> &
+  (
+    | {
+        paymentLogoIcon?: IOLogoPaymentType;
+        icon?: never;
+      }
+    | {
+        icon?: IOIcons;
+        paymentLogoIcon?: never;
+      }
+  );
+
+const PAYMENT_LOGO_SIZE: IOIconSizeScale = 24;
 
 export const ListItemInfo = ({
   label,
   value,
   numberOfLines = 2,
   icon,
+  paymentLogoIcon,
   endElement,
   accessibilityLabel,
   testID
@@ -138,6 +152,14 @@ export const ListItemInfo = ({
               name={icon}
               color="grey-450"
               size={IOListItemVisualParams.iconSize}
+            />
+          </View>
+        )}
+        {paymentLogoIcon && (
+          <View style={{ marginRight: IOListItemVisualParams.iconMargin }}>
+            <LogoPaymentWithFallback
+              brand={paymentLogoIcon}
+              size={PAYMENT_LOGO_SIZE}
             />
           </View>
         )}


### PR DESCRIPTION
## Short description
This PR adds the ability to show a payment logo for the `ListItemInfo` component.

## List of changes proposed in this pull request
- Added prop `paymentLogoIcon` so that if it is added, the `icon` props should not be indicated.
- Added an example into the example app with a payment logo indicated

## How to test
Run the example app and navigate through the List item section, you should be able to see a list item info that has a payment logo.

## Related design 
https://www.figma.com/design/SDaOSTsQnJUxmoPQEfz3bJ/Ricevuta-di-pagamento-pagoPA?node-id=501-7279&t=LEssmiht33qKZ8ls-4

## Preview
<img width="295" alt="image" src="https://github.com/pagopa/io-app-design-system/assets/34343582/8742f99a-9532-4b78-a238-d995a29caaf7">

