### PR TITLE
[IOBP-653] Add `backTestID` to `HeaderSecondLevel`

### DIFF
--- a/src/components/layout/HeaderSecondLevel.tsx
+++ b/src/components/layout/HeaderSecondLevel.tsx
@@ -36,10 +36,12 @@ type BackProps =
   | {
       goBack: () => void;
       backAccessibilityLabel: string;
+      backTestID?: string;
     }
   | {
       goBack?: never;
       backAccessibilityLabel?: never;
+      backTestID?: never;
     };
 
 type CommonProps = WithTestID<{
@@ -121,6 +123,7 @@ export const HeaderSecondLevel = ({
   scrollValues = undefined,
   goBack,
   backAccessibilityLabel,
+  backTestID,
   title,
   type,
   transparent = false,
@@ -197,6 +200,7 @@ export const HeaderSecondLevel = ({
             color="neutral"
             onPress={goBack}
             accessibilityLabel={backAccessibilityLabel}
+            testID={backTestID}
           />
         ) : (
           <HSpacer size={32} />


### PR DESCRIPTION
## Short description
This PR adds the `backTestID` prop to the `Back` button in the `HeaderSecondLevel` component. This change is necessary because some `BaseScreenComponent` instances in `io-app` have this property for testing purposes.

## List of changes proposed in this pull request
- Add `backTestID` to the `HeaderSecondLevel`

## How to test
N/A