### PR TITLE
[IOPID-1531] fix radio button accessibility on android

### DIFF
--- a/src/components/listitems/ListItemRadio.tsx
+++ b/src/components/listitems/ListItemRadio.tsx
@@ -274,7 +274,10 @@ export const ListItemRadio = ({
               </H6>
             </View>
             <HSpacer size={8} />
-            <View pointerEvents="none">
+            <View
+              pointerEvents="none"
+              importantForAccessibility="no-hide-descendants"
+            >
               <AnimatedRadio checked={selected ?? toggleValue} />
             </View>
           </View>


### PR DESCRIPTION
## Short description
add `importantForAccessibility="no-hide-descendants"` to read correctly on Android the accessibility label 

## DEMO A11Y 
> [!Important]
> On iOS the accessibility was read correctly and there was no regression, so there is no video 

<p>

| 🤖 Android OLD 🤖 |🤖 Android NEW 🤖 |
| - | - |
| <video src="https://github.com/pagopa/io-app-design-system/assets/83651704/2853912f-0bba-42f9-94e0-c415efe1a9f5"/> | <video src="https://github.com/pagopa/io-app-design-system/assets/83651704/29c24245-7712-451b-8c3b-4985c0f6ddf1"/> |

</p>