### PR TITLE
[IOAPPX-312] Fix wrong font weight in `ListItemHeader` when experimental DS is off

### DIFF
--- a/src/components/listitems/ListItemHeader.tsx
+++ b/src/components/listitems/ListItemHeader.tsx
@@ -79,7 +79,7 @@ export const ListItemHeader = ({
           endElement !== undefined && endElement.type !== "badge"
         }
       >
-        <H6 role="heading" weight="Regular" color={theme["textBody-tertiary"]}>
+        <H6 role="heading" color={theme["textBody-tertiary"]}>
           {label}
         </H6>
       </View>


### PR DESCRIPTION
## Short description
This PR fixes the wrong font weight in `ListItemHeader` when experimental DS is off.

**Before →** Titillium, regular font weight
**After →** Titillium, semibold font weight

## List of changes proposed in this pull request
- Remove `weight="regular"` prop that forced a regular font weight also in the typographic style (DS off)

## How to test
N/A