### PR TITLE
chore: Add `keepCancelVisible` prop on SearchInput

### DIFF
--- a/example/src/pages/SearchCustom.tsx
+++ b/example/src/pages/SearchCustom.tsx
@@ -6,7 +6,7 @@ import {
 } from "@pagopa/io-app-design-system";
 import { useNavigation } from "@react-navigation/native";
 import React from "react";
-import { Alert, ScrollView } from "react-native";
+import { Alert, Platform, ScrollView } from "react-native";
 
 export const SearchCustom = () => {
   const navigation = useNavigation();
@@ -14,36 +14,42 @@ export const SearchCustom = () => {
 
   return (
     <ScrollView
-      keyboardShouldPersistTaps="always"
       contentContainerStyle={{
         padding: IOVisualCostants.appMarginDefault
       }}
+      keyboardDismissMode={Platform.select({
+        ios: "interactive",
+        default: "on-drag"
+      })}
+      keyboardShouldPersistTaps="handled"
     >
       <VStack space={32}>
         <VStack space={8}>
           <H4>Basic behavior</H4>
           <SearchInput
-            clearAccessibilityLabel="Cancella"
-            placeholder="Cerca nei messaggi"
+            autoFocus
             accessibilityLabel="Search input"
             cancelButtonLabel="Annulla"
-            value={inputValue}
+            clearAccessibilityLabel="Cancella"
+            keepCancelVisible
             onCancel={() => navigation.goBack()}
             onChangeText={setInputValue}
+            placeholder="Cerca nei messaggi"
+            value={inputValue}
           />
         </VStack>
         <VStack space={8}>
           <H4>Pressable behavior</H4>
           <SearchInput
+            accessibilityLabel="Search input"
+            cancelButtonLabel="Annulla"
+            clearAccessibilityLabel="Cancella"
+            placeholder="Cerca nei messaggi"
             pressable={{
               onPress: () => {
                 Alert.alert("Pressed");
               }
             }}
-            clearAccessibilityLabel="Cancella"
-            placeholder="Cerca nei messaggi"
-            accessibilityLabel="Search input"
-            cancelButtonLabel="Annulla"
           />
         </VStack>
       </VStack>

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "prettify": "prettier --write \"src/**/*.(ts|tsx)\"",
     "prepack": "bob build",
-    "prepare": "bob build",
     "release": "release-it",
     "example": "yarn --cwd example",
     "bootstrap": "yarn example && yarn install",

--- a/src/components/searchInput/SearchInput.tsx
+++ b/src/components/searchInput/SearchInput.tsx
@@ -106,7 +106,7 @@ export const SearchInput = forwardRef<SearchInputRef, SearchInputProps>(
       clearAccessibilityLabel,
       placeholder,
       autoFocus,
-      keepCancelVisible = true,
+      keepCancelVisible = false,
       onCancel,
       onChangeText,
       pressable,

--- a/src/components/searchInput/SearchInput.tsx
+++ b/src/components/searchInput/SearchInput.tsx
@@ -64,12 +64,14 @@ type SearchInputPressableProps = {
 type SearchInputActionProps =
   | {
       pressable: SearchInputPressableProps;
+      keepCancelVisible?: never;
       onCancel?: never;
       onChangeText?: never;
       value?: never;
     }
   | {
       pressable?: never;
+      keepCancelVisible?: boolean;
       onCancel: (event: GestureResponderEvent) => void;
       onChangeText: (value: string) => void;
       value: string;
@@ -102,13 +104,14 @@ export const SearchInput = forwardRef<SearchInputRef, SearchInputProps>(
       accessibilityLabel,
       cancelButtonLabel,
       clearAccessibilityLabel,
+      placeholder,
+      autoFocus,
+      keepCancelVisible = true,
       onCancel,
       onChangeText,
-      placeholder,
-      value = "",
-      autoFocus,
       pressable,
-      testID
+      testID,
+      value = ""
     },
     ref
   ) => {
@@ -159,19 +162,24 @@ export const SearchInput = forwardRef<SearchInputRef, SearchInputProps>(
     }));
 
     /* Applied to the `Cancel` button */
-    const cancelButtonAnimatedStyle = useAnimatedStyle(() => ({
-      transform: [
-        {
-          translateX: interpolate(
-            isFocused.value,
-            [0, 1],
-            [cancelButtonWidth + IOVisualCostants.appMarginDefault, 0],
-            Extrapolate.CLAMP
-          )
-        }
-      ],
-      opacity: interpolate(isFocused.value, [0, 1], [0.5, 1])
-    }));
+    const cancelButtonAnimatedStyle = useAnimatedStyle(() => {
+      const showCancelButton =
+        !pressable && keepCancelVisible ? 1 : isFocused.value;
+
+      return {
+        transform: [
+          {
+            translateX: interpolate(
+              showCancelButton,
+              [0, 1],
+              [cancelButtonWidth + IOVisualCostants.appMarginDefault, 0],
+              Extrapolate.CLAMP
+            )
+          }
+        ],
+        opacity: interpolate(showCancelButton, [0, 1], [0.5, 1])
+      };
+    });
 
     /* Applied to the `Clear` button inside the `SearchInput` */
     const clearButtonAnimatedStyle = useAnimatedStyle(() => {
@@ -197,7 +205,9 @@ export const SearchInput = forwardRef<SearchInputRef, SearchInputProps>(
 
     const handleBlur = () => {
       isFocused.value = withTiming(0, inputWithTimingConfig);
-      inputAnimatedWidth.value = inputWidth;
+      inputAnimatedWidth.value = keepCancelVisible
+        ? inputWidthWithCancel
+        : inputWidth;
     };
 
     const cancel = useCallback(


### PR DESCRIPTION
## Short description
This PR adds `keepCancelVisible` prop on SearchInput component in order to keep the cancel button visible when the input loses focus.

## How to test
1. Launch the example app
2. Go to the **SearchCustom** screen
