### PR TITLE
[IOAPPX-324] Fix `HeaderSecondLevel` UI regression

### DIFF
--- a/src/components/layout/HeaderSecondLevel.tsx
+++ b/src/components/layout/HeaderSecondLevel.tsx
@@ -207,9 +207,8 @@ export const HeaderSecondLevel = ({
       style={[
         { borderBottomWidth: 1, borderColor: borderColorTransparentState },
         isModal ? { borderColor: borderColorSolidState } : {},
-        transparent
-          ? headerWrapperAnimatedStyle
-          : { backgroundColor: headerBgColorSolidState }
+        !transparent ? { backgroundColor: headerBgColorSolidState } : {},
+        headerWrapperAnimatedStyle
       ]}
     >
       <Animated.View


### PR DESCRIPTION
## Short description
This PR fixes the `HeaderSecondLevel` UI regression, introduced by mistake with the following PR:
* https://github.com/pagopa/io-app-design-system/pull/285
The problem 

## List of changes proposed in this pull request
- Apply the `animatedStyle` in all the conditions

### Preview
(Please look at the header's bottom border)
| Before | After |
|--------|--------|
| <video src="https://github.com/pagopa/io-app-design-system/assets/1255491/cafdf95b-b4a4-4b5c-a316-21708a04c758" /> | <video src="https://github.com/pagopa/io-app-design-system/assets/1255491/96dc7c95-e658-4f12-95ff-e4b9efed3565" /> |  

## How to test
1. Launch the example app
2. Check out every example that's using `HeaderSecondLevel`