### PR TITLE
[IOAPPX-326] Fix bug on Android when using `SemiBold` font weight

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -8,8 +8,8 @@
 <link rel="preload" href="TitilliumSansPro-BlackItalic.otf" as="font" />
 <link rel="preload" href="TitilliumSansPro-Bold.otf" as="font" />
 <link rel="preload" href="TitilliumSansPro-BoldItalic.otf" as="font" />
-<link rel="preload" href="TitilliumSansPro-SemiBold.otf" as="font" />
-<link rel="preload" href="TitilliumSansPro-SemiBoldItalic.otf" as="font" />
+<link rel="preload" href="TitilliumSansPro-Semibold.otf" as="font" />
+<link rel="preload" href="TitilliumSansPro-SemiboldItalic.otf" as="font" />
 <link rel="preload" href="TitilliumSansPro-Regular.otf" as="font" />
 <link rel="preload" href="TitilliumSansPro-Italic.otf" as="font" />
 <link rel="preload" href="TitilliumSansPro-Light.otf" as="font" />

--- a/example/src/pages/Advice.tsx
+++ b/example/src/pages/Advice.tsx
@@ -48,7 +48,7 @@ export const DSAdvice = () => (
 
 const renderFeatureInfo = () => (
   <>
-    <H2 color={"bluegrey"} weight={"SemiBold"} style={{ marginBottom: 16 }}>
+    <H2 color={"bluegrey"} weight={"Semibold"} style={{ marginBottom: 16 }}>
       FeatureInfo
     </H2>
     <ComponentViewerBox name="FeatureInfo · with Icon">
@@ -104,7 +104,7 @@ const renderBanner = () => (
   <>
     <H2
       color={"bluegrey"}
-      weight={"SemiBold"}
+      weight={"Semibold"}
       style={{
         marginBottom: 16,
         paddingTop: IOVisualCostants.appMarginDefault

--- a/example/src/pages/Alert.tsx
+++ b/example/src/pages/Alert.tsx
@@ -16,7 +16,7 @@ export const DSAlert = () => {
       {/* Content only */}
       <H2
         color={"bluegrey"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{
           marginBottom: 16,
           paddingTop: IOVisualCostants.appMarginDefault
@@ -56,7 +56,7 @@ export const DSAlert = () => {
 
       <VSpacer size={40} />
 
-      <H2 color={"bluegrey"} weight={"SemiBold"} style={{ marginBottom: 16 }}>
+      <H2 color={"bluegrey"} weight={"Semibold"} style={{ marginBottom: 16 }}>
         Title + Content
       </H2>
 
@@ -105,7 +105,7 @@ export const DSAlert = () => {
 
       <VSpacer size={40} />
 
-      <H2 color={"bluegrey"} weight={"SemiBold"} style={{ marginBottom: 16 }}>
+      <H2 color={"bluegrey"} weight={"Semibold"} style={{ marginBottom: 16 }}>
         Content + Action
       </H2>
 
@@ -158,7 +158,7 @@ export const DSAlert = () => {
       <VSpacer size={40} />
 
       {/* Full width */}
-      <H2 color={"bluegrey"} weight={"SemiBold"} style={{ marginBottom: 16 }}>
+      <H2 color={"bluegrey"} weight={"Semibold"} style={{ marginBottom: 16 }}>
         Full width
       </H2>
       <FullWidthComponent>

--- a/example/src/pages/Buttons.tsx
+++ b/example/src/pages/Buttons.tsx
@@ -45,7 +45,7 @@ export const Buttons = () => {
       {/* The title should be dynamic, got from the route object */}
       <H2
         color={"bluegrey"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{
           marginBottom: 16,
           paddingTop: IOVisualCostants.appMarginDefault
@@ -293,7 +293,7 @@ export const Buttons = () => {
 
       <H2
         color={"bluegrey"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ButtonOutline
@@ -452,7 +452,7 @@ export const Buttons = () => {
 
       <H2
         color={"bluegrey"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ButtonLink
@@ -597,7 +597,7 @@ export const Buttons = () => {
 
       <H2
         color={"bluegrey"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         IconButton
@@ -710,7 +710,7 @@ export const Buttons = () => {
 
       <H2
         color={"bluegrey"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         IconButtonSolid
@@ -778,7 +778,7 @@ export const Buttons = () => {
 
       <H2
         color={"bluegrey"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         IconButtonContained (Icebox)
@@ -864,7 +864,7 @@ export const Buttons = () => {
 
       <H2
         color={"bluegrey"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ButtonExtendedOutline
@@ -895,7 +895,7 @@ export const Buttons = () => {
 
       <H2
         color={"bluegrey"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         Specific buttons

--- a/example/src/pages/Colors.tsx
+++ b/example/src/pages/Colors.tsx
@@ -265,7 +265,7 @@ export const Colors = () => (
     {/* Gradients */}
     <H2
       color={"bluegrey"}
-      weight={"SemiBold"}
+      weight={"Semibold"}
       style={{ marginBottom: sectionTitleMargin }}
     >
       Gradients

--- a/example/src/pages/Icons.tsx
+++ b/example/src/pages/Icons.tsx
@@ -102,7 +102,7 @@ export const Icons = () => {
       </View>
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12 }}
       >
         Navigation
@@ -125,7 +125,7 @@ export const Icons = () => {
       </View>
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12 }}
       >
         System
@@ -148,7 +148,7 @@ export const Icons = () => {
       </View>
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12 }}
       >
         Biometric
@@ -171,7 +171,7 @@ export const Icons = () => {
       </View>
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12 }}
       >
         Categories
@@ -194,7 +194,7 @@ export const Icons = () => {
       </View>
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12 }}
       >
         Product

--- a/example/src/pages/ListItem.tsx
+++ b/example/src/pages/ListItem.tsx
@@ -35,7 +35,7 @@ export const ListItems = () => {
     <Screen>
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ListItemNav
@@ -49,7 +49,7 @@ export const ListItems = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ListItemInfoCopy
@@ -58,7 +58,7 @@ export const ListItems = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ListItemInfo
@@ -67,7 +67,7 @@ export const ListItems = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ListItemHeader
@@ -76,7 +76,7 @@ export const ListItems = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ListItemAmount
@@ -85,7 +85,7 @@ export const ListItems = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ListItemAction
@@ -94,7 +94,7 @@ export const ListItems = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ListItemTransaction
@@ -102,7 +102,7 @@ export const ListItems = () => {
       {renderListItemTransaction()}
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ListItemRadio
@@ -110,7 +110,7 @@ export const ListItems = () => {
       {renderListItemRadio()}
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ListItemRadioWithAmount

--- a/example/src/pages/Logos.tsx
+++ b/example/src/pages/Logos.tsx
@@ -51,7 +51,7 @@ export const Logos = () => {
     <Screen>
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{
           marginBottom: 12,
           paddingTop: IOVisualCostants.appMarginDefault
@@ -65,7 +65,7 @@ export const Logos = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12 }}
       >
         Payment Networks (Small)
@@ -74,7 +74,7 @@ export const Logos = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12 }}
       >
         Payment Networks (Big)
@@ -83,7 +83,7 @@ export const Logos = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12 }}
       >
         Payment Networks (Card)

--- a/example/src/pages/Modules.tsx
+++ b/example/src/pages/Modules.tsx
@@ -304,7 +304,7 @@ const Modules = () => {
       />
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ModuleIDP
@@ -312,7 +312,7 @@ const Modules = () => {
       {renderModuleIDP()}
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ModulePaymentNotice
@@ -320,7 +320,7 @@ const Modules = () => {
       {renderModulePaymentNotice()}
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ModuleCheckout
@@ -328,7 +328,7 @@ const Modules = () => {
       {renderModuleCheckout()}
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ModuleAttachment
@@ -336,7 +336,7 @@ const Modules = () => {
       {renderModuleAttachment()}
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ModuleCredential
@@ -344,7 +344,7 @@ const Modules = () => {
       {renderModuleCredential()}
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ModuleNavigation

--- a/example/src/pages/Pictograms.tsx
+++ b/example/src/pages/Pictograms.tsx
@@ -77,7 +77,7 @@ export const Pictograms = () => {
     <Screen>
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{
           marginBottom: 16,
           paddingTop: IOVisualCostants.appMarginDefault
@@ -104,7 +104,7 @@ export const Pictograms = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{
           marginBottom: 16,
           paddingTop: IOVisualCostants.appMarginDefault
@@ -131,7 +131,7 @@ export const Pictograms = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{
           marginBottom: 16,
           paddingTop: IOVisualCostants.appMarginDefault
@@ -156,7 +156,7 @@ export const Pictograms = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{
           marginBottom: 16,
           paddingTop: IOVisualCostants.appMarginDefault
@@ -202,7 +202,7 @@ export const Pictograms = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{
           marginBottom: 16,
           paddingTop: IOVisualCostants.appMarginDefault

--- a/src/components/badge/Badge.tsx
+++ b/src/components/badge/Badge.tsx
@@ -64,7 +64,7 @@ const styles = StyleSheet.create({
   },
   // TODO: Remove this when legacy look is deprecated https://pagopa.atlassian.net/browse/IOPLT-153
   legacyLabelFont: {
-    ...makeFontStyleObject("SemiBold", false, "TitilliumSansPro")
+    ...makeFontStyleObject("Semibold", false, "TitilliumSansPro")
   }
 });
 

--- a/src/components/banner/__test__/__snapshots__/banner.test.tsx.snap
+++ b/src/components/banner/__test__/__snapshots__/banner.test.tsx.snap
@@ -432,7 +432,7 @@ exports[`Test Banner Components Banner Snapshot 1`] = `
         allowFontScaling={false}
         color="blueIO-850"
         defaultColor="black"
-        defaultWeight="SemiBold"
+        defaultWeight="Semibold"
         font="TitilliumSansPro"
         fontStyle={
           {
@@ -454,7 +454,7 @@ exports[`Test Banner Components Banner Snapshot 1`] = `
             },
           ]
         }
-        weight="SemiBold"
+        weight="Semibold"
       >
         Banner title
       </Text>

--- a/src/components/buttons/__test__/__snapshots__/button.test.tsx.snap
+++ b/src/components/buttons/__test__/__snapshots__/button.test.tsx.snap
@@ -968,7 +968,7 @@ exports[`Test Buttons Components ButtonExtendedOutline Snapshot 1`] = `
         allowFontScaling={false}
         color="black"
         defaultColor="black"
-        defaultWeight="SemiBold"
+        defaultWeight="Semibold"
         font="TitilliumSansPro"
         fontStyle={
           {
@@ -990,7 +990,7 @@ exports[`Test Buttons Components ButtonExtendedOutline Snapshot 1`] = `
             },
           ]
         }
-        weight="SemiBold"
+        weight="Semibold"
       >
         label
       </Text>

--- a/src/components/layout/HeaderSecondLevel.tsx
+++ b/src/components/layout/HeaderSecondLevel.tsx
@@ -112,7 +112,7 @@ const styles = StyleSheet.create({
     ...makeFontStyleObject("Regular", false, "ReadexPro")
   },
   headerTitleLegacyFont: {
-    ...makeFontStyleObject("SemiBold", false, "TitilliumSansPro")
+    ...makeFontStyleObject("Semibold", false, "TitilliumSansPro")
   }
 });
 

--- a/src/components/listitems/ListItemAction.tsx
+++ b/src/components/listitems/ListItemAction.tsx
@@ -53,7 +53,7 @@ const legacyStyles = StyleSheet.create({
   labelLegacy: {
     fontSize: buttonTextFontSize,
     lineHeight: 20,
-    ...makeFontStyleObject("SemiBold", false, "TitilliumSansPro")
+    ...makeFontStyleObject("Semibold", false, "TitilliumSansPro")
   }
 });
 

--- a/src/components/listitems/ListItemAmount.tsx
+++ b/src/components/listitems/ListItemAmount.tsx
@@ -78,7 +78,7 @@ export const ListItemAmount = ({
         )}
         <View style={IOStyles.flex}>{itemInfoTextComponent}</View>
         <H3
-          weight={"SemiBold"}
+          weight={"Semibold"}
           color={"black"}
           {...valueElementProps}
           accessibilityLabel={`${listItemAccessibilityLabel}; ${

--- a/src/components/listitems/ListItemNavAlert.tsx
+++ b/src/components/listitems/ListItemNavAlert.tsx
@@ -58,7 +58,7 @@ export const ListItemNavAlert = ({
       {description && (
         <>
           {typeof description === "string" ? (
-            <LabelSmall weight="SemiBold" color={theme.errorText}>
+            <LabelSmall weight="Semibold" color={theme.errorText}>
               {description}
             </LabelSmall>
           ) : (

--- a/src/components/listitems/__test__/__snapshots__/listitem.test.tsx.snap
+++ b/src/components/listitems/__test__/__snapshots__/listitem.test.tsx.snap
@@ -2060,7 +2060,7 @@ exports[`Test List Item Components ListItemInfo Snapshot 1`] = `
           allowFontScaling={false}
           color="black"
           defaultColor="black"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -2083,7 +2083,7 @@ exports[`Test List Item Components ListItemInfo Snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           testValue
         </Text>
@@ -2201,7 +2201,7 @@ exports[`Test List Item Components ListItemInfoCopy Snapshot 1`] = `
           allowFontScaling={false}
           color="blue"
           defaultColor="black"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -2224,7 +2224,7 @@ exports[`Test List Item Components ListItemInfoCopy Snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           testValue
         </Text>
@@ -2379,7 +2379,7 @@ exports[`Test List Item Components ListItemNav Snapshot 1`] = `
           allowFontScaling={false}
           color="black"
           defaultColor="black"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -2401,7 +2401,7 @@ exports[`Test List Item Components ListItemNav Snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           testValue
         </Text>
@@ -2616,7 +2616,7 @@ exports[`Test List Item Components ListItemNavAlert Snapshot 1`] = `
           allowFontScaling={false}
           color="black"
           defaultColor="black"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -2638,7 +2638,7 @@ exports[`Test List Item Components ListItemNavAlert Snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           testValue
         </Text>
@@ -2793,7 +2793,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 1`] = `
           allowFontScaling={false}
           color="black"
           defaultColor="black"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -2816,7 +2816,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           label
         </Text>
@@ -2950,7 +2950,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 1`] = `
           allowFontScaling={false}
           color="blueIO-500"
           defaultColor="black"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -2972,7 +2972,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           € 1.000,00
         </Text>
@@ -3209,7 +3209,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 2`] = `
           allowFontScaling={false}
           color="black"
           defaultColor="black"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -3232,7 +3232,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 2`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           label
         </Text>
@@ -3256,7 +3256,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 2`] = `
           allowFontScaling={false}
           color="blueIO-500"
           defaultColor="black"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -3278,7 +3278,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 2`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           € 1.000,00
         </Text>

--- a/src/components/modules/ModuleIDP.tsx
+++ b/src/components/modules/ModuleIDP.tsx
@@ -38,7 +38,7 @@ const styles = StyleSheet.create({
     ...makeFontStyleObject("Regular", false, "ReadexPro")
   },
   idpLegacyNameFont: {
-    ...makeFontStyleObject("SemiBold", false, "TitilliumSansPro")
+    ...makeFontStyleObject("Semibold", false, "TitilliumSansPro")
   },
   idpLogo: {
     marginStart: IOListItemLogoMargin,

--- a/src/components/modules/ModulePaymentNotice.tsx
+++ b/src/components/modules/ModulePaymentNotice.tsx
@@ -103,7 +103,7 @@ const ModulePaymentNoticeContent = ({
             {subtitle}
           </LabelSmallAlt>
         ) : (
-          <LabelSmall weight="SemiBold" color={"bluegrey"} numberOfLines={2}>
+          <LabelSmall weight="Semibold" color={"bluegrey"} numberOfLines={2}>
             {subtitle}
           </LabelSmall>
         )}

--- a/src/components/numberpad/__test__/__snapshots__/NumberPad.test.tsx.snap
+++ b/src/components/numberpad/__test__/__snapshots__/NumberPad.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
           allowFontScaling={false}
           color="white"
           defaultColor="bluegreyDark"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -106,7 +106,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           1
         </Text>
@@ -173,7 +173,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
           allowFontScaling={false}
           color="white"
           defaultColor="bluegreyDark"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -195,7 +195,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           2
         </Text>
@@ -262,7 +262,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
           allowFontScaling={false}
           color="white"
           defaultColor="bluegreyDark"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -284,7 +284,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           3
         </Text>
@@ -374,7 +374,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
           allowFontScaling={false}
           color="white"
           defaultColor="bluegreyDark"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -396,7 +396,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           4
         </Text>
@@ -463,7 +463,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
           allowFontScaling={false}
           color="white"
           defaultColor="bluegreyDark"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -485,7 +485,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           5
         </Text>
@@ -552,7 +552,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
           allowFontScaling={false}
           color="white"
           defaultColor="bluegreyDark"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -574,7 +574,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           6
         </Text>
@@ -664,7 +664,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
           allowFontScaling={false}
           color="white"
           defaultColor="bluegreyDark"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -686,7 +686,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           7
         </Text>
@@ -753,7 +753,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
           allowFontScaling={false}
           color="white"
           defaultColor="bluegreyDark"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -775,7 +775,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           8
         </Text>
@@ -842,7 +842,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
           allowFontScaling={false}
           color="white"
           defaultColor="bluegreyDark"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -864,7 +864,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           9
         </Text>
@@ -1095,7 +1095,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
           allowFontScaling={false}
           color="white"
           defaultColor="bluegreyDark"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             {
@@ -1117,7 +1117,7 @@ exports[`NumberPad Should match the snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           0
         </Text>

--- a/src/components/otpInput/BoxedInput.tsx
+++ b/src/components/otpInput/BoxedInput.tsx
@@ -38,7 +38,7 @@ const styles = StyleSheet.create({
 const SecretValue = () => (
   <BaseTypography
     font="DMMono"
-    weight="SemiBold"
+    weight="Semibold"
     color="bluegreyDark"
     fontStyle={{ fontSize: 22, lineHeight: 33 }}
     accessible={false}

--- a/src/components/switch/SwitchLabel.tsx
+++ b/src/components/switch/SwitchLabel.tsx
@@ -30,7 +30,7 @@ const styles = StyleSheet.create({
     lineHeight: 24,
     color: IOColors.bluegreyDark,
     flexShrink: 1,
-    ...makeFontStyleObject("SemiBold", undefined, "TitilliumSansPro")
+    ...makeFontStyleObject("Semibold", undefined, "TitilliumSansPro")
   }
 });
 

--- a/src/components/tag/Tag.tsx
+++ b/src/components/tag/Tag.tsx
@@ -81,7 +81,7 @@ const styles = StyleSheet.create({
   },
   // TODO: Remove this when legacy look is deprecated https://pagopa.atlassian.net/browse/IOPLT-153
   legacyLabelFont: {
-    ...makeFontStyleObject("SemiBold", false, "TitilliumSansPro")
+    ...makeFontStyleObject("Semibold", false, "TitilliumSansPro")
   }
 });
 

--- a/src/components/textInput/TextInputBase.tsx
+++ b/src/components/textInput/TextInputBase.tsx
@@ -111,7 +111,7 @@ const styles = StyleSheet.create({
   },
   // TODO: Remove this when legacy look is deprecated https://pagopa.atlassian.net/browse/IOPLT-153
   textInputStyleLegacyFont: {
-    ...makeFontStyleObject("SemiBold", false, "TitilliumSansPro")
+    ...makeFontStyleObject("Semibold", false, "TitilliumSansPro")
   },
   textInputLabelWrapper: {
     position: "absolute",

--- a/src/components/typography/Body.tsx
+++ b/src/components/typography/Body.tsx
@@ -10,7 +10,7 @@ type PartialAllowedColors = Extract<
   "bluegreyDark" | "white" | "blue" | "bluegrey" | "bluegreyLight"
 >;
 type AllowedColors = PartialAllowedColors | IOTheme["textBody-default"];
-type AllowedWeight = IOFontWeight | "Regular" | "SemiBold";
+type AllowedWeight = IOFontWeight | "Regular" | "Semibold";
 
 type BodyProps = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>

--- a/src/components/typography/ButtonText.tsx
+++ b/src/components/typography/ButtonText.tsx
@@ -7,7 +7,7 @@ import { useTypographyFactory } from "./Factory";
 import { ExternalTypographyProps, TypographyProps } from "./common";
 
 export type ButtonTextAllowedColors = IOColors;
-type AllowedWeight = Extract<IOFontWeight, "SemiBold" | "Regular" | "Bold">;
+type AllowedWeight = Extract<IOFontWeight, "Semibold" | "Regular" | "Bold">;
 
 type ButtonTextProps = ExternalTypographyProps<
   TypographyProps<AllowedWeight, ButtonTextAllowedColors>

--- a/src/components/typography/Chip.tsx
+++ b/src/components/typography/Chip.tsx
@@ -6,7 +6,7 @@ import { useTypographyFactory } from "./Factory";
 import { ExternalTypographyProps, TypographyProps } from "./common";
 
 type AllowedColors = IOColors;
-type AllowedWeight = Extract<IOFontWeight, "SemiBold" | "Regular">;
+type AllowedWeight = Extract<IOFontWeight, "Semibold" | "Regular">;
 
 type ChipProps = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>

--- a/src/components/typography/H1.tsx
+++ b/src/components/typography/H1.tsx
@@ -6,7 +6,7 @@ import { useTypographyFactory } from "./Factory";
 import { ExternalTypographyProps, TypographyProps } from "./common";
 
 type AllowedColors = IOTheme["textHeading-default"];
-type AllowedWeight = Extract<IOFontWeight, "Regular" | "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Regular" | "Semibold">;
 
 type H1Props = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>
@@ -14,13 +14,13 @@ type H1Props = ExternalTypographyProps<
 
 export const h1FontSize = 28;
 export const h1LineHeight = 42;
-const font: FontFamily = "ReadexPro";
+const fontName: FontFamily = "ReadexPro";
 const defaultColor: AllowedColors = "black";
 const defaultWeight: AllowedWeight = "Regular";
 
 // TODO: Remove this when legacy look is deprecated https://pagopa.atlassian.net/browse/IOPLT-153
 const legacyFont: FontFamily = "TitilliumSansPro";
-const legacyDefaultWeight: AllowedWeight = "SemiBold";
+const legacyDefaultWeight: AllowedWeight = "Semibold";
 const legacyH1FontSize = 31;
 const legacyH1LineHeight = 43;
 
@@ -35,7 +35,7 @@ export const H1 = React.forwardRef<View, H1Props>((props, ref) => {
       ...props,
       defaultWeight: isExperimental ? defaultWeight : legacyDefaultWeight,
       defaultColor,
-      font: isExperimental ? font : legacyFont,
+      font: isExperimental ? fontName : legacyFont,
       fontStyle: {
         fontSize: isExperimental ? h1FontSize : legacyH1FontSize,
         lineHeight: isExperimental ? h1LineHeight : legacyH1LineHeight

--- a/src/components/typography/H2.tsx
+++ b/src/components/typography/H2.tsx
@@ -6,7 +6,7 @@ import { useTypographyFactory } from "./Factory";
 import { ExternalTypographyProps, TypographyProps } from "./common";
 
 type AllowedColors = IOTheme["textHeading-default"];
-type AllowedWeight = Extract<IOFontWeight, "SemiBold" | "Regular">;
+type AllowedWeight = Extract<IOFontWeight, "Semibold" | "Regular">;
 
 type H2Props = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>
@@ -14,13 +14,13 @@ type H2Props = ExternalTypographyProps<
 
 export const h2FontSize = 26;
 export const h2LineHeight = 39;
-const font: FontFamily = "ReadexPro";
+const fontName: FontFamily = "ReadexPro";
 const defaultColor: AllowedColors = "black";
 const defaultWeight: AllowedWeight = "Regular";
 
 // TODO: Remove this when legacy look is deprecated https://pagopa.atlassian.net/browse/IOPLT-153
 const legacyFont: FontFamily = "TitilliumSansPro";
-const legacyDefaultWeight: AllowedWeight = "SemiBold";
+const legacyDefaultWeight: AllowedWeight = "Semibold";
 const legacyH2FontSize = 28;
 const legacyH2LineHeight = 40;
 
@@ -35,7 +35,7 @@ export const H2 = React.forwardRef<View, H2Props>((props, ref) => {
       ...props,
       defaultWeight: isExperimental ? defaultWeight : legacyDefaultWeight,
       defaultColor,
-      font: isExperimental ? font : legacyFont,
+      font: isExperimental ? fontName : legacyFont,
       fontStyle: {
         fontSize: isExperimental ? h2FontSize : legacyH2FontSize,
         lineHeight: isExperimental ? h2LineHeight : legacyH2LineHeight

--- a/src/components/typography/H3.tsx
+++ b/src/components/typography/H3.tsx
@@ -6,7 +6,7 @@ import { useTypographyFactory } from "./Factory";
 import { ExternalTypographyProps, TypographyProps } from "./common";
 
 type AllowedColors = IOTheme["textHeading-default"];
-type AllowedWeight = Extract<IOFontWeight, "SemiBold" | "Regular">;
+type AllowedWeight = Extract<IOFontWeight, "Semibold" | "Regular">;
 
 type H3Props = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>
@@ -15,14 +15,14 @@ type H3Props = ExternalTypographyProps<
 /* Common typographic styles */
 export const h3FontSize = 22;
 export const h3LineHeight = 33;
-const font: FontFamily = "ReadexPro";
+const fontName: FontFamily = "ReadexPro";
 const defaultColor: AllowedColors = "black";
 const defaultWeight: AllowedWeight = "Regular";
 
 // TODO: Remove this when legacy look is deprecated https://pagopa.atlassian.net/browse/IOPLT-153
 const legacyFontName: FontFamily = "TitilliumSansPro";
 const legacyDefaultColor: AllowedColors = "bluegreyDark";
-const legacyDefaultWeight: AllowedWeight = "SemiBold";
+const legacyDefaultWeight: AllowedWeight = "Semibold";
 const legacyH3FontSize = 24;
 const legacyH3LineHeight = 34;
 /**
@@ -36,7 +36,7 @@ export const H3 = React.forwardRef<View, H3Props>((props, ref) => {
       ...props,
       defaultWeight: isExperimental ? defaultWeight : legacyDefaultWeight,
       defaultColor: isExperimental ? defaultColor : legacyDefaultColor,
-      font: isExperimental ? font : legacyFontName,
+      font: isExperimental ? fontName : legacyFontName,
       fontStyle: {
         fontSize: isExperimental ? h3FontSize : legacyH3FontSize,
         lineHeight: isExperimental ? h3LineHeight : legacyH3LineHeight

--- a/src/components/typography/H4.tsx
+++ b/src/components/typography/H4.tsx
@@ -6,7 +6,7 @@ import { useTypographyFactory } from "./Factory";
 import { ExternalTypographyProps, TypographyProps } from "./common";
 
 type AllowedColors = IOTheme["textHeading-default"];
-type AllowedWeight = Extract<IOFontWeight, "Regular" | "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Regular" | "Semibold">;
 
 type H4Props = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>
@@ -21,7 +21,7 @@ const defaultWeight: AllowedWeight = "Regular";
 // TODO: Remove this when legacy look is deprecated https://pagopa.atlassian.net/browse/IOPLT-153
 const legacyFontName: FontFamily = "TitilliumSansPro";
 const legacyDefaultColor: AllowedColors = "bluegreyDark";
-const legacyDefaultWeight: AllowedWeight = "SemiBold";
+const legacyDefaultWeight: AllowedWeight = "Semibold";
 const legacyH4FontSize = 22;
 
 /**

--- a/src/components/typography/H5.tsx
+++ b/src/components/typography/H5.tsx
@@ -6,7 +6,7 @@ import { useTypographyFactory } from "./Factory";
 import { ExternalTypographyProps, TypographyProps } from "./common";
 
 type AllowedColors = IOTheme["textHeading-default"];
-type AllowedWeight = Extract<IOFontWeight, "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Semibold">;
 
 type H5Props = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>
@@ -16,7 +16,7 @@ export const h5FontSize = 14;
 export const h5LineHeight = 16;
 const font: FontFamily = "TitilliumSansPro";
 const defaultColor: AllowedColors = "black";
-const defaultWeight: AllowedWeight = "SemiBold";
+const defaultWeight: AllowedWeight = "Semibold";
 
 /**
  * `H5` typographic style

--- a/src/components/typography/H6.tsx
+++ b/src/components/typography/H6.tsx
@@ -7,7 +7,7 @@ import { ExternalTypographyProps, TypographyProps } from "./common";
 
 // when the weight is bold, only these color are allowed
 type AllowedColors = IOTheme["textBody-default"] | "blueIO-850";
-type AllowedWeight = Extract<IOFontWeight, "Regular" | "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Regular" | "Semibold">;
 
 type H6Props = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>
@@ -23,7 +23,7 @@ const fontName: FontFamily = "ReadexPro";
 const legacyFontSize = 18;
 const legacyLineHeight = 25;
 const legacyFontName: FontFamily = "TitilliumSansPro";
-const legacyDefaultWeight: AllowedWeight = "SemiBold";
+const legacyDefaultWeight: AllowedWeight = "Semibold";
 
 /**
  * `H6` typographic style

--- a/src/components/typography/Hero.tsx
+++ b/src/components/typography/Hero.tsx
@@ -6,7 +6,7 @@ import { useTypographyFactory } from "./Factory";
 import { ExternalTypographyProps, TypographyProps } from "./common";
 
 type AllowedColors = IOTheme["textHeading-default"];
-type AllowedWeight = Extract<IOFontWeight, "Regular" | "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Regular" | "Semibold">;
 
 type HeroProps = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>
@@ -14,13 +14,13 @@ type HeroProps = ExternalTypographyProps<
 
 export const heroFontSize = 32;
 export const heroLineHeight = 48;
-const font: FontFamily = "ReadexPro";
+const fontName: FontFamily = "ReadexPro";
 const defaultColor: AllowedColors = "black";
 const defaultWeight: AllowedWeight = "Regular";
 
 // TODO: Remove this when legacy look is deprecated https://pagopa.atlassian.net/browse/IOPLT-153
 const legacyFont: FontFamily = "TitilliumSansPro";
-const legacyWeight: AllowedWeight = "SemiBold";
+const legacyWeight: AllowedWeight = "Semibold";
 const legacyHeroFontSize = 35;
 const legacyHeroLineHeight = 49;
 
@@ -35,7 +35,7 @@ export const Hero = React.forwardRef<View, HeroProps>((props, ref) => {
       ...props,
       defaultWeight: isExperimental ? defaultWeight : legacyWeight,
       defaultColor,
-      font: isExperimental ? font : legacyFont,
+      font: isExperimental ? fontName : legacyFont,
       fontStyle: {
         fontSize: isExperimental ? heroFontSize : legacyHeroFontSize,
         lineHeight: isExperimental ? heroLineHeight : legacyHeroLineHeight

--- a/src/components/typography/Label.tsx
+++ b/src/components/typography/Label.tsx
@@ -13,7 +13,7 @@ import {
 
 type PartialAllowedColors = Extract<IOColors, "black" | "white">;
 type AllowedColors = PartialAllowedColors | IOColorsStatusForeground;
-type AllowedWeight = Extract<IOFontWeight, "Bold" | "Regular" | "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Bold" | "Regular" | "Semibold">;
 type LabelProps = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>
 > & { fontSize?: FontSize };

--- a/src/components/typography/LabelHeader.tsx
+++ b/src/components/typography/LabelHeader.tsx
@@ -11,7 +11,7 @@ type AllowedColors =
   | "grey-850"
   | "white"
   | "black";
-type AllowedWeight = Extract<IOFontWeight, "Regular" | "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Regular" | "Semibold">;
 
 type LabelHeaderProps = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>
@@ -26,7 +26,7 @@ const labelHeaderDefaultWeight: AllowedWeight = "Regular";
 
 // TODO: Remove this when legacy look is deprecated https://pagopa.atlassian.net/browse/IOPLT-153
 const legacyLabelHeaderFontName: IOFontFamily = "TitilliumSansPro";
-const legacyLabelHeaderWeight: AllowedWeight = "SemiBold";
+const legacyLabelHeaderWeight: AllowedWeight = "Semibold";
 const legacyLabelHeaderLineHeight = 20;
 /**
  * `LabelHeader` typographic style

--- a/src/components/typography/LabelLink.tsx
+++ b/src/components/typography/LabelLink.tsx
@@ -12,7 +12,7 @@ import {
 } from "./common";
 
 type AllowedColors = IOColors;
-type AllowedWeight = Extract<IOFontWeight, "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Semibold">;
 type AllowedFontSize = { fontSize?: FontSize };
 
 type LinkProps = ExternalTypographyProps<
@@ -24,7 +24,7 @@ const font: IOFontFamily = "TitilliumSansPro";
 
 export const linkLegacyDefaultColor: AllowedColors = "blue";
 export const linkDefaultColor: AllowedColors = "blueIO-500";
-export const linkDefaultWeight: AllowedWeight = "SemiBold";
+export const linkDefaultWeight: AllowedWeight = "Semibold";
 
 /**
  * `Link` typographic style

--- a/src/components/typography/LabelSmall.tsx
+++ b/src/components/typography/LabelSmall.tsx
@@ -16,7 +16,7 @@ type PartialAllowedColors = Extract<
   | "grey-200"
 >;
 type AllowedColors = PartialAllowedColors | IOTheme["textBody-tertiary"];
-type AllowedWeight = Extract<IOFontWeight, "Bold" | "Regular" | "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Bold" | "Regular" | "Semibold">;
 
 type FontSize = "regular" | "small";
 type AllowedFontSize = { fontSize?: FontSize };

--- a/src/components/typography/LabelSmallAlt.tsx
+++ b/src/components/typography/LabelSmallAlt.tsx
@@ -17,7 +17,7 @@ type PartialAllowedColors = Extract<
   | "grey-200"
 >;
 type AllowedColors = PartialAllowedColors | IOTheme["textBody-tertiary"];
-type AllowedWeight = Extract<IOFontWeight, "Bold" | "Regular" | "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Bold" | "Regular" | "Semibold">;
 
 type LabelSmallAltProps = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>
@@ -32,7 +32,7 @@ const defaultWeight: AllowedWeight = "Regular";
 // TODO: Remove this when legacy look is deprecated https://pagopa.atlassian.net/browse/IOPLT-153
 const legacyLabelFontSize = 16;
 const legacyFontName: FontFamily = "TitilliumSansPro";
-const legacyDefaultWeight: AllowedWeight = "SemiBold";
+const legacyDefaultWeight: AllowedWeight = "Semibold";
 
 /**
  * `LabelSmallAlt` typographic style. It's referenced as `LabelSmallReadex` in the design projects.

--- a/src/components/typography/README.md
+++ b/src/components/typography/README.md
@@ -2,11 +2,11 @@
 
 ## Handling font files
 
-The application uses the font _Titillium Sans Pro_. Fonts are handled differently than Android and iOS. To use the font, `TitilliumSansPro-SemiBold` example, you must apply the following properties for Android:
+The application uses the font _Titillium Sans Pro_. Fonts are handled differently than Android and iOS. To use the font, `TitilliumSansPro-Semibold` example, you must apply the following properties for Android:
 
 ```css
 {
-  fontFamily: 'TitilliumSansPro-SemiBold'
+  fontFamily: 'TitilliumSansPro-Semibold'
 }
 ```
 

--- a/src/components/typography/__test__/__snapshots__/typography.test.tsx.snap
+++ b/src/components/typography/__test__/__snapshots__/typography.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`Test Typography Components H1 Snapshot 1`] = `
   allowFontScaling={false}
   color="black"
   defaultColor="black"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -124,7 +124,7 @@ exports[`Test Typography Components H1 Snapshot 1`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -135,7 +135,7 @@ exports[`Test Typography Components H1 Snapshot 2`] = `
   allowFontScaling={false}
   color="white"
   defaultColor="black"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -157,7 +157,7 @@ exports[`Test Typography Components H1 Snapshot 2`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -168,7 +168,7 @@ exports[`Test Typography Components H2 Snapshot 1`] = `
   allowFontScaling={false}
   color="black"
   defaultColor="black"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -190,7 +190,7 @@ exports[`Test Typography Components H2 Snapshot 1`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -201,7 +201,7 @@ exports[`Test Typography Components H3 Snapshot 1`] = `
   allowFontScaling={false}
   color="bluegreyDark"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -223,7 +223,7 @@ exports[`Test Typography Components H3 Snapshot 1`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -234,7 +234,7 @@ exports[`Test Typography Components H3 Snapshot 2`] = `
   allowFontScaling={false}
   color="bluegreyLight"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -256,7 +256,7 @@ exports[`Test Typography Components H3 Snapshot 2`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -267,7 +267,7 @@ exports[`Test Typography Components H3 Snapshot 3`] = `
   allowFontScaling={false}
   color="white"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -289,7 +289,7 @@ exports[`Test Typography Components H3 Snapshot 3`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -300,7 +300,7 @@ exports[`Test Typography Components H3 Snapshot 4`] = `
   allowFontScaling={false}
   color="white"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -322,7 +322,7 @@ exports[`Test Typography Components H3 Snapshot 4`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -333,7 +333,7 @@ exports[`Test Typography Components H3 Snapshot 5`] = `
   allowFontScaling={false}
   color="bluegreyDark"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -355,7 +355,7 @@ exports[`Test Typography Components H3 Snapshot 5`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -366,7 +366,7 @@ exports[`Test Typography Components H4 Snapshot 1`] = `
   allowFontScaling={false}
   color="bluegreyDark"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -388,7 +388,7 @@ exports[`Test Typography Components H4 Snapshot 1`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -399,7 +399,7 @@ exports[`Test Typography Components H4 Snapshot 2`] = `
   allowFontScaling={false}
   color="blue"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -421,7 +421,7 @@ exports[`Test Typography Components H4 Snapshot 2`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -432,7 +432,7 @@ exports[`Test Typography Components H4 Snapshot 3`] = `
   allowFontScaling={false}
   color="white"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -454,7 +454,7 @@ exports[`Test Typography Components H4 Snapshot 3`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -465,7 +465,7 @@ exports[`Test Typography Components H4 Snapshot 4`] = `
   allowFontScaling={false}
   color="bluegreyDark"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -498,7 +498,7 @@ exports[`Test Typography Components H4 Snapshot 5`] = `
   allowFontScaling={false}
   color="bluegrey"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -531,7 +531,7 @@ exports[`Test Typography Components H4 Snapshot 6`] = `
   allowFontScaling={false}
   color="bluegreyLight"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -564,7 +564,7 @@ exports[`Test Typography Components H4 Snapshot 7`] = `
   allowFontScaling={false}
   color="white"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -597,7 +597,7 @@ exports[`Test Typography Components H5 Snapshot 1`] = `
   allowFontScaling={false}
   color="black"
   defaultColor="black"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -623,7 +623,7 @@ exports[`Test Typography Components H5 Snapshot 1`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -634,7 +634,7 @@ exports[`Test Typography Components H5 Snapshot 2`] = `
   allowFontScaling={false}
   color="bluegrey"
   defaultColor="black"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -660,7 +660,7 @@ exports[`Test Typography Components H5 Snapshot 2`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -671,7 +671,7 @@ exports[`Test Typography Components H5 Snapshot 3`] = `
   allowFontScaling={false}
   color="blue"
   defaultColor="black"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -697,7 +697,7 @@ exports[`Test Typography Components H5 Snapshot 3`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -708,7 +708,7 @@ exports[`Test Typography Components H5 Snapshot 4`] = `
   allowFontScaling={false}
   color="white"
   defaultColor="black"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -734,7 +734,7 @@ exports[`Test Typography Components H5 Snapshot 4`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -745,7 +745,7 @@ exports[`Test Typography Components H6 Snapshot 1`] = `
   allowFontScaling={false}
   color="black"
   defaultColor="black"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -767,7 +767,7 @@ exports[`Test Typography Components H6 Snapshot 1`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -1009,7 +1009,7 @@ exports[`Test Typography Components Link Snapshot 1`] = `
   allowFontScaling={false}
   color="blue"
   defaultColor="blue"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     {
@@ -1033,7 +1033,7 @@ exports[`Test Typography Components Link Snapshot 1`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>

--- a/src/components/typography/markdown/MdH2.tsx
+++ b/src/components/typography/markdown/MdH2.tsx
@@ -4,17 +4,19 @@ import { ExternalTypographyProps, TypographyProps } from "../common";
 import { useTypographyFactory } from "../Factory";
 
 type AllowedColors = Extract<IOTheme, "textHeading-default"> | IOColors;
-type AllowedWeight = Extract<IOFontWeight, "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Regular">;
 
 type MdH2Props = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>
 >;
 
-const fontSize = 16;
+/* We set 18 instead of 16 to diffrentiate from the H3 typographic style.
+It should be 16 with `SemiBold` font weight. */
+const fontSize = 18;
 const lineHeight = 24;
 const font: FontFamily = "ReadexPro";
 const defaultColor: AllowedColors = "black";
-const defaultWeight: AllowedWeight = "SemiBold";
+const defaultWeight: AllowedWeight = "Regular";
 
 /**
  * `MdH2` typographic style

--- a/src/components/typography/markdown/MdH4.tsx
+++ b/src/components/typography/markdown/MdH4.tsx
@@ -4,7 +4,7 @@ import { ExternalTypographyProps, TypographyProps } from "../common";
 import { useTypographyFactory } from "../Factory";
 
 type AllowedColors = Extract<IOTheme, "textHeading-default"> | IOColors;
-type AllowedWeight = Extract<IOFontWeight, "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Semibold">;
 
 type MdH4Props = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>
@@ -14,7 +14,7 @@ const fontSize = 14;
 const lineHeight = 24;
 const font: FontFamily = "TitilliumSansPro";
 const defaultColor: AllowedColors = "grey-700";
-const defaultWeight: AllowedWeight = "SemiBold";
+const defaultWeight: AllowedWeight = "Semibold";
 
 /**
  * `MdH4` typographic style

--- a/src/utils/fonts.ts
+++ b/src/utils/fonts.ts
@@ -29,7 +29,7 @@ const fonts = {
 
 export type IOFontFamily = keyof typeof fonts;
 
-const weights = ["Light", "Regular", "Medium", "SemiBold", "Bold"] as const;
+const weights = ["Light", "Regular", "Medium", "Semibold", "Bold"] as const;
 export type IOFontWeight = (typeof weights)[number];
 
 const weightValues = ["300", "400", "500", "600", "700"] as const;
@@ -43,7 +43,7 @@ export const fontWeights: Record<IOFontWeight, FontWeightValue> = {
   Light: "300",
   Regular: "400",
   Medium: "500",
-  SemiBold: "600",
+  Semibold: "600",
   Bold: "700"
 };
 
@@ -58,7 +58,7 @@ export const fontWeightsMap: Record<IOFontWeight, FontWeightValue> = {
   Light: "300",
   Regular: "400",
   Medium: "500",
-  SemiBold: "600",
+  Semibold: "600",
   Bold: "700"
 };
 


### PR DESCRIPTION
## Short description
This PR fixes a critical UI bug on Android when using the `SemiBold` font weight. The new _**Titillium Sans Pro**_ uses `Semibold` as a font attribute, while the previous _**Titillium Web**_ fonts used `SemiBold`. Android didn't handle this edge case and rendered everything with the fallback system font.
  
## List of changes proposed in this pull request
- Replace `SemiBold` font weight attribute with `Semibold` in all the typographic styles
- Temporarily update `MDH2` with a different font size to distinguish it from `MDH3`

## How to test
1. Launch the example app with an Android physical or virtual device
2. Check **Typography** screen