### PR TITLE
[IOAPPX-331] Add legacy `blue` to `Pictogram`, when experimental DS is off

### DIFF
--- a/src/core/IOColors.ts
+++ b/src/core/IOColors.ts
@@ -317,7 +317,8 @@ export const IOThemeLight: IOTheme = {
 export const IOThemeLightLegacy: IOTheme = {
   ...IOThemeLight,
   "appBackground-accent": "blue",
-  "interactiveElem-default": "blue"
+  "interactiveElem-default": "blue",
+  "pictogram-hands": "blue"
 };
 
 export const IOThemeDark: IOTheme = {


### PR DESCRIPTION
## Short description
This PR enables the rendering of the legacy `blue` to `Pictogram` component, when experimental DS is off.

## List of changes proposed in this pull request
- Add relative theme key to `IOThemeLightLegacy`

### Preview

https://github.com/pagopa/io-app-design-system/assets/1255491/638b6645-723a-4229-9957-69eae37d7aeb



## How to test
1. Launch the example app
2. Go to the **Pictograms** screen with DS enabled or disabled