### PR TITLE
Decrease `H4` and `H3` font sizes (legacy version)

### DIFF
--- a/src/components/numberpad/__test__/__snapshots__/NumberPad.test.tsx.snap
+++ b/src/components/numberpad/__test__/__snapshots__/NumberPad.test.tsx.snap
@@ -89,16 +89,16 @@ exports[`NumberPad Should match the snapshot 1`] = `
           font="TitilliumSansPro"
           fontStyle={
             {
-              "fontSize": 24,
-              "lineHeight": 34,
+              "fontSize": 22,
+              "lineHeight": 33,
             }
           }
           maxFontSizeMultiplier={1.25}
           style={
             [
               {
-                "fontSize": 24,
-                "lineHeight": 34,
+                "fontSize": 22,
+                "lineHeight": 33,
               },
               {
                 "color": "#FFFFFF",
@@ -180,16 +180,16 @@ exports[`NumberPad Should match the snapshot 1`] = `
           font="TitilliumSansPro"
           fontStyle={
             {
-              "fontSize": 24,
-              "lineHeight": 34,
+              "fontSize": 22,
+              "lineHeight": 33,
             }
           }
           maxFontSizeMultiplier={1.25}
           style={
             [
               {
-                "fontSize": 24,
-                "lineHeight": 34,
+                "fontSize": 22,
+                "lineHeight": 33,
               },
               {
                 "color": "#FFFFFF",
@@ -271,16 +271,16 @@ exports[`NumberPad Should match the snapshot 1`] = `
           font="TitilliumSansPro"
           fontStyle={
             {
-              "fontSize": 24,
-              "lineHeight": 34,
+              "fontSize": 22,
+              "lineHeight": 33,
             }
           }
           maxFontSizeMultiplier={1.25}
           style={
             [
               {
-                "fontSize": 24,
-                "lineHeight": 34,
+                "fontSize": 22,
+                "lineHeight": 33,
               },
               {
                 "color": "#FFFFFF",
@@ -385,16 +385,16 @@ exports[`NumberPad Should match the snapshot 1`] = `
           font="TitilliumSansPro"
           fontStyle={
             {
-              "fontSize": 24,
-              "lineHeight": 34,
+              "fontSize": 22,
+              "lineHeight": 33,
             }
           }
           maxFontSizeMultiplier={1.25}
           style={
             [
               {
-                "fontSize": 24,
-                "lineHeight": 34,
+                "fontSize": 22,
+                "lineHeight": 33,
               },
               {
                 "color": "#FFFFFF",
@@ -476,16 +476,16 @@ exports[`NumberPad Should match the snapshot 1`] = `
           font="TitilliumSansPro"
           fontStyle={
             {
-              "fontSize": 24,
-              "lineHeight": 34,
+              "fontSize": 22,
+              "lineHeight": 33,
             }
           }
           maxFontSizeMultiplier={1.25}
           style={
             [
               {
-                "fontSize": 24,
-                "lineHeight": 34,
+                "fontSize": 22,
+                "lineHeight": 33,
               },
               {
                 "color": "#FFFFFF",
@@ -567,16 +567,16 @@ exports[`NumberPad Should match the snapshot 1`] = `
           font="TitilliumSansPro"
           fontStyle={
             {
-              "fontSize": 24,
-              "lineHeight": 34,
+              "fontSize": 22,
+              "lineHeight": 33,
             }
           }
           maxFontSizeMultiplier={1.25}
           style={
             [
               {
-                "fontSize": 24,
-                "lineHeight": 34,
+                "fontSize": 22,
+                "lineHeight": 33,
               },
               {
                 "color": "#FFFFFF",
@@ -681,16 +681,16 @@ exports[`NumberPad Should match the snapshot 1`] = `
           font="TitilliumSansPro"
           fontStyle={
             {
-              "fontSize": 24,
-              "lineHeight": 34,
+              "fontSize": 22,
+              "lineHeight": 33,
             }
           }
           maxFontSizeMultiplier={1.25}
           style={
             [
               {
-                "fontSize": 24,
-                "lineHeight": 34,
+                "fontSize": 22,
+                "lineHeight": 33,
               },
               {
                 "color": "#FFFFFF",
@@ -772,16 +772,16 @@ exports[`NumberPad Should match the snapshot 1`] = `
           font="TitilliumSansPro"
           fontStyle={
             {
-              "fontSize": 24,
-              "lineHeight": 34,
+              "fontSize": 22,
+              "lineHeight": 33,
             }
           }
           maxFontSizeMultiplier={1.25}
           style={
             [
               {
-                "fontSize": 24,
-                "lineHeight": 34,
+                "fontSize": 22,
+                "lineHeight": 33,
               },
               {
                 "color": "#FFFFFF",
@@ -863,16 +863,16 @@ exports[`NumberPad Should match the snapshot 1`] = `
           font="TitilliumSansPro"
           fontStyle={
             {
-              "fontSize": 24,
-              "lineHeight": 34,
+              "fontSize": 22,
+              "lineHeight": 33,
             }
           }
           maxFontSizeMultiplier={1.25}
           style={
             [
               {
-                "fontSize": 24,
-                "lineHeight": 34,
+                "fontSize": 22,
+                "lineHeight": 33,
               },
               {
                 "color": "#FFFFFF",
@@ -1118,16 +1118,16 @@ exports[`NumberPad Should match the snapshot 1`] = `
           font="TitilliumSansPro"
           fontStyle={
             {
-              "fontSize": 24,
-              "lineHeight": 34,
+              "fontSize": 22,
+              "lineHeight": 33,
             }
           }
           maxFontSizeMultiplier={1.25}
           style={
             [
               {
-                "fontSize": 24,
-                "lineHeight": 34,
+                "fontSize": 22,
+                "lineHeight": 33,
               },
               {
                 "color": "#FFFFFF",

--- a/src/components/typography/H3.tsx
+++ b/src/components/typography/H3.tsx
@@ -23,8 +23,6 @@ const defaultWeight: AllowedWeight = "Regular";
 const legacyFontName: FontFamily = "TitilliumSansPro";
 const legacyDefaultColor: AllowedColors = "bluegreyDark";
 const legacyDefaultWeight: AllowedWeight = "Semibold";
-const legacyH3FontSize = 24;
-const legacyH3LineHeight = 34;
 /**
  * `H3` typographic style
  */
@@ -41,8 +39,8 @@ export const H3 = React.forwardRef<View, H3Props>((props, ref) => {
       defaultColor: isExperimental ? defaultColor : legacyDefaultColor,
       font: isExperimental ? fontName : legacyFontName,
       fontStyle: {
-        fontSize: isExperimental ? h3FontSize : legacyH3FontSize,
-        lineHeight: isExperimental ? h3LineHeight : legacyH3LineHeight
+        fontSize: h3FontSize,
+        lineHeight: h3LineHeight
       }
     },
     ref

--- a/src/components/typography/H4.tsx
+++ b/src/components/typography/H4.tsx
@@ -22,7 +22,6 @@ const defaultWeight: AllowedWeight = "Regular";
 const legacyFontName: FontFamily = "TitilliumSansPro";
 const legacyDefaultColor: AllowedColors = "bluegreyDark";
 const legacyDefaultWeight: AllowedWeight = "Semibold";
-const legacyH4FontSize = 22;
 
 /**
  * `H4` typographic style
@@ -39,7 +38,7 @@ export const H4 = React.forwardRef<View, H4Props>((props, ref) => {
       defaultColor: isExperimental ? defaultColor : legacyDefaultColor,
       font: isExperimental ? font : legacyFontName,
       fontStyle: {
-        fontSize: isExperimental ? h4FontSize : legacyH4FontSize,
+        fontSize: h4FontSize,
         lineHeight: h4LineHeight
       }
     },

--- a/src/components/typography/__test__/__snapshots__/typography.test.tsx.snap
+++ b/src/components/typography/__test__/__snapshots__/typography.test.tsx.snap
@@ -392,7 +392,7 @@ exports[`Test Typography Components H4 Snapshot 1`] = `
   font="TitilliumSansPro"
   fontStyle={
     {
-      "fontSize": 22,
+      "fontSize": 20,
       "lineHeight": 24,
     }
   }
@@ -400,7 +400,7 @@ exports[`Test Typography Components H4 Snapshot 1`] = `
   style={
     [
       {
-        "fontSize": 22,
+        "fontSize": 20,
         "lineHeight": 24,
       },
       {
@@ -427,7 +427,7 @@ exports[`Test Typography Components H4 Snapshot 2`] = `
   font="TitilliumSansPro"
   fontStyle={
     {
-      "fontSize": 22,
+      "fontSize": 20,
       "lineHeight": 24,
     }
   }
@@ -435,7 +435,7 @@ exports[`Test Typography Components H4 Snapshot 2`] = `
   style={
     [
       {
-        "fontSize": 22,
+        "fontSize": 20,
         "lineHeight": 24,
       },
       {
@@ -462,7 +462,7 @@ exports[`Test Typography Components H4 Snapshot 3`] = `
   font="TitilliumSansPro"
   fontStyle={
     {
-      "fontSize": 22,
+      "fontSize": 20,
       "lineHeight": 24,
     }
   }
@@ -470,7 +470,7 @@ exports[`Test Typography Components H4 Snapshot 3`] = `
   style={
     [
       {
-        "fontSize": 22,
+        "fontSize": 20,
         "lineHeight": 24,
       },
       {
@@ -497,7 +497,7 @@ exports[`Test Typography Components H4 Snapshot 4`] = `
   font="TitilliumSansPro"
   fontStyle={
     {
-      "fontSize": 22,
+      "fontSize": 20,
       "lineHeight": 24,
     }
   }
@@ -505,7 +505,7 @@ exports[`Test Typography Components H4 Snapshot 4`] = `
   style={
     [
       {
-        "fontSize": 22,
+        "fontSize": 20,
         "lineHeight": 24,
       },
       {
@@ -532,7 +532,7 @@ exports[`Test Typography Components H4 Snapshot 5`] = `
   font="TitilliumSansPro"
   fontStyle={
     {
-      "fontSize": 22,
+      "fontSize": 20,
       "lineHeight": 24,
     }
   }
@@ -540,7 +540,7 @@ exports[`Test Typography Components H4 Snapshot 5`] = `
   style={
     [
       {
-        "fontSize": 22,
+        "fontSize": 20,
         "lineHeight": 24,
       },
       {
@@ -567,7 +567,7 @@ exports[`Test Typography Components H4 Snapshot 6`] = `
   font="TitilliumSansPro"
   fontStyle={
     {
-      "fontSize": 22,
+      "fontSize": 20,
       "lineHeight": 24,
     }
   }
@@ -575,7 +575,7 @@ exports[`Test Typography Components H4 Snapshot 6`] = `
   style={
     [
       {
-        "fontSize": 22,
+        "fontSize": 20,
         "lineHeight": 24,
       },
       {
@@ -602,7 +602,7 @@ exports[`Test Typography Components H4 Snapshot 7`] = `
   font="TitilliumSansPro"
   fontStyle={
     {
-      "fontSize": 22,
+      "fontSize": 20,
       "lineHeight": 24,
     }
   }
@@ -610,7 +610,7 @@ exports[`Test Typography Components H4 Snapshot 7`] = `
   style={
     [
       {
-        "fontSize": 22,
+        "fontSize": 20,
         "lineHeight": 24,
       },
       {

--- a/src/components/typography/__test__/__snapshots__/typography.test.tsx.snap
+++ b/src/components/typography/__test__/__snapshots__/typography.test.tsx.snap
@@ -217,16 +217,16 @@ exports[`Test Typography Components H3 Snapshot 1`] = `
   font="TitilliumSansPro"
   fontStyle={
     {
-      "fontSize": 24,
-      "lineHeight": 34,
+      "fontSize": 22,
+      "lineHeight": 33,
     }
   }
   maxFontSizeMultiplier={1.25}
   style={
     [
       {
-        "fontSize": 24,
-        "lineHeight": 34,
+        "fontSize": 22,
+        "lineHeight": 33,
       },
       {
         "color": "#17324D",
@@ -252,16 +252,16 @@ exports[`Test Typography Components H3 Snapshot 2`] = `
   font="TitilliumSansPro"
   fontStyle={
     {
-      "fontSize": 24,
-      "lineHeight": 34,
+      "fontSize": 22,
+      "lineHeight": 33,
     }
   }
   maxFontSizeMultiplier={1.25}
   style={
     [
       {
-        "fontSize": 24,
-        "lineHeight": 34,
+        "fontSize": 22,
+        "lineHeight": 33,
       },
       {
         "color": "#CCD4DC",
@@ -287,16 +287,16 @@ exports[`Test Typography Components H3 Snapshot 3`] = `
   font="TitilliumSansPro"
   fontStyle={
     {
-      "fontSize": 24,
-      "lineHeight": 34,
+      "fontSize": 22,
+      "lineHeight": 33,
     }
   }
   maxFontSizeMultiplier={1.25}
   style={
     [
       {
-        "fontSize": 24,
-        "lineHeight": 34,
+        "fontSize": 22,
+        "lineHeight": 33,
       },
       {
         "color": "#FFFFFF",
@@ -322,16 +322,16 @@ exports[`Test Typography Components H3 Snapshot 4`] = `
   font="TitilliumSansPro"
   fontStyle={
     {
-      "fontSize": 24,
-      "lineHeight": 34,
+      "fontSize": 22,
+      "lineHeight": 33,
     }
   }
   maxFontSizeMultiplier={1.25}
   style={
     [
       {
-        "fontSize": 24,
-        "lineHeight": 34,
+        "fontSize": 22,
+        "lineHeight": 33,
       },
       {
         "color": "#FFFFFF",
@@ -357,16 +357,16 @@ exports[`Test Typography Components H3 Snapshot 5`] = `
   font="TitilliumSansPro"
   fontStyle={
     {
-      "fontSize": 24,
-      "lineHeight": 34,
+      "fontSize": 22,
+      "lineHeight": 33,
     }
   }
   maxFontSizeMultiplier={1.25}
   style={
     [
       {
-        "fontSize": 24,
-        "lineHeight": 34,
+        "fontSize": 22,
+        "lineHeight": 33,
       },
       {
         "color": "#17324D",


### PR DESCRIPTION
## Short description
This PR decreases `H4` and `H3` font sizes (legacy version only). This is necessary to avoid noticeable differences between the new and legacy versions of the same typographic style, especially on the new Services section.

## List of changes proposed in this pull request
- Decrease H4 font size
- Decrease H3 font size

## How to test
N/A