### PR TITLE
[IOCOM-1600] Support for grey-700 on Label

### DIFF
--- a/src/components/typography/Label.tsx
+++ b/src/components/typography/Label.tsx
@@ -16,7 +16,7 @@ import {
   lineHeightMapping
 } from "./common";
 
-type PartialAllowedColors = Extract<IOColors, "black" | "white">;
+type PartialAllowedColors = Extract<IOColors, "black" | "white" | "grey-700">;
 type AllowedColors = PartialAllowedColors | IOColorsStatusForeground;
 type AllowedWeight = Extract<IOFontWeight, "Bold" | "Regular" | "Semibold">;
 type LabelProps = ExternalTypographyProps<


### PR DESCRIPTION
## Short description
This PR adds support for grey-700 color on Label.

## List of changes proposed in this pull request
- grey-700 added to allowedcolors on Label