### PR TITLE
[IOAPPX-362] Change `Label…` default weight to Semibold + Fix autocomplete of `IOText` when using `font` prop 

### DIFF
--- a/src/components/typography/Label.tsx
+++ b/src/components/typography/Label.tsx
@@ -30,7 +30,7 @@ export const Label = forwardRef<View, LabelProps>(
     const LabelProps: IOTextProps = {
       ...props,
       font: "TitilliumSansPro",
-      weight: customWeight ?? "Bold",
+      weight: customWeight ?? "Semibold",
       size: 16,
       lineHeight: 24,
       color: customColor ?? defaultColor,

--- a/src/components/typography/LabelMini.tsx
+++ b/src/components/typography/LabelMini.tsx
@@ -31,7 +31,7 @@ export const LabelMini = forwardRef<View, LabelMiniProps>(
       ...props,
       dynamicTypeRamp: "footnote" /* iOS only */,
       font: "TitilliumSansPro",
-      weight: customWeight ?? "Bold",
+      weight: customWeight ?? "Semibold",
       size: 12,
       lineHeight: 18,
       color: customColor ?? defaultColor,

--- a/src/components/typography/LabelSmall.tsx
+++ b/src/components/typography/LabelSmall.tsx
@@ -31,7 +31,7 @@ export const LabelSmall = forwardRef<View, LabelSmallProps>(
       ...props,
       dynamicTypeRamp: "footnote" /* iOS only */,
       font: "TitilliumSansPro",
-      weight: customWeight ?? "Bold",
+      weight: customWeight ?? "Semibold",
       size: 14,
       lineHeight: 21,
       color: customColor ?? defaultColor,

--- a/src/components/typography/__test__/__snapshots__/typography.test.tsx.snap
+++ b/src/components/typography/__test__/__snapshots__/typography.test.tsx.snap
@@ -462,7 +462,7 @@ exports[`Test Typography Components Label Snapshot 1`] = `
         "fontFamily": "Titillium Sans Pro",
         "fontSize": 16,
         "fontStyle": "normal",
-        "fontWeight": "700",
+        "fontWeight": "600",
         "lineHeight": 24,
       },
     ]
@@ -484,7 +484,7 @@ exports[`Test Typography Components Label Snapshot 2`] = `
         "fontFamily": "Titillium Sans Pro",
         "fontSize": 16,
         "fontStyle": "normal",
-        "fontWeight": "700",
+        "fontWeight": "600",
         "lineHeight": 24,
       },
     ]
@@ -507,7 +507,7 @@ exports[`Test Typography Components LabelSmall Snapshot 1`] = `
         "fontFamily": "Titillium Sans Pro",
         "fontSize": 14,
         "fontStyle": "normal",
-        "fontWeight": "700",
+        "fontWeight": "600",
         "lineHeight": 21,
       },
     ]
@@ -530,7 +530,7 @@ exports[`Test Typography Components LabelSmall Snapshot 2`] = `
         "fontFamily": "Titillium Sans Pro",
         "fontSize": 14,
         "fontStyle": "normal",
-        "fontWeight": "700",
+        "fontWeight": "600",
         "lineHeight": 21,
       },
     ]
@@ -553,7 +553,7 @@ exports[`Test Typography Components LabelSmall Snapshot 3`] = `
         "fontFamily": "Titillium Sans Pro",
         "fontSize": 14,
         "fontStyle": "normal",
-        "fontWeight": "700",
+        "fontWeight": "600",
         "lineHeight": 21,
       },
     ]
@@ -576,7 +576,7 @@ exports[`Test Typography Components LabelSmall Snapshot 4`] = `
         "fontFamily": "Titillium Sans Pro",
         "fontSize": 14,
         "fontStyle": "normal",
-        "fontWeight": "700",
+        "fontWeight": "600",
         "lineHeight": 21,
       },
     ]
@@ -599,7 +599,7 @@ exports[`Test Typography Components LabelSmall Snapshot 5`] = `
         "fontFamily": "Titillium Sans Pro",
         "fontSize": 14,
         "fontStyle": "normal",
-        "fontWeight": "700",
+        "fontWeight": "600",
         "lineHeight": 21,
       },
     ]
@@ -625,7 +625,7 @@ exports[`Test Typography Components Link Snapshot 1`] = `
         "fontFamily": "Titillium Sans Pro",
         "fontSize": 16,
         "fontStyle": "normal",
-        "fontWeight": "700",
+        "fontWeight": "600",
         "lineHeight": 24,
       },
     ]

--- a/src/utils/fonts.ts
+++ b/src/utils/fonts.ts
@@ -9,7 +9,7 @@ import { Platform, TextStyle } from "react-native";
 /**
  * Choose the font name based on the platform
  */
-const fonts: Record<string, string> = {
+const fonts = {
   TitilliumSansPro: Platform.select({
     android: "TitilliumSansPro",
     web: "TitilliumSansPro",
@@ -28,7 +28,7 @@ const fonts: Record<string, string> = {
     ios: "DM Mono",
     default: "DMMono"
   })
-};
+} as const;
 
 export type IOFontFamily = keyof typeof fonts;
 
@@ -64,7 +64,9 @@ export const fontWeights: Record<IOFontWeight, IOFontWeightNumeric> = {
 
 type FontStyleObject = {
   fontSize: IOFontSize;
-  fontFamily: IOFontFamily;
+  /* We also accept `string` because Android needs a composed 
+  fontFamily name, like `TitilliumSansPro-Regular` */
+  fontFamily: string | IOFontFamily;
   fontWeight?: IOFontWeightNumeric;
   lineHeight?: TextStyle["lineHeight"];
   fontStyle?: TextStyle["fontStyle"];
@@ -94,7 +96,7 @@ export const makeFontFamilyName = (
   font: IOFontFamily,
   weight: IOFontWeight = defaultWeight,
   fontStyle: TextStyle["fontStyle"] = "normal"
-): IOFontFamily =>
+): FontStyleObject["fontFamily"] =>
   Platform.select({
     web: fonts[font],
     android: `${fonts[font]}-${weight || "Regular"}${

--- a/src/utils/fonts.ts
+++ b/src/utils/fonts.ts
@@ -28,7 +28,7 @@ const fonts = {
     ios: "DM Mono",
     default: "DMMono"
   })
-} as const;
+};
 
 export type IOFontFamily = keyof typeof fonts;
 


### PR DESCRIPTION
## Short description
This PR fixes a number of issues that were encountered when adding `IOText` to the main repo

## List of changes proposed in this pull request
- Set `Label…` default weight to `Semibold`, instead of `Bold` → https://github.com/pagopa/io-app-design-system/commit/13819ba2ef5df2811bd7254c861020b8cf9d9cb4
- Fix wrong autocomplete of `IOText` when using `font` prop → https://github.com/pagopa/io-app-design-system/commit/6f1496c7235d32bf05b5256e62e87fcf38b1abb8
- Update `Label…` snapshots → https://github.com/pagopa/io-app-design-system/pull/322/commits/0ffdfcd8653afeb70069b3bf793b97e497f88af5

## How to test
N/A