### PR TITLE
[IOPID-2111] Fix `ListItemInfo` screen reader behaviour

### DIFF
--- a/src/components/badge/Badge.tsx
+++ b/src/components/badge/Badge.tsx
@@ -164,6 +164,7 @@ export const Badge = ({ text, outline = false, variant, testID }: Badge) => {
 
   return (
     <View
+      accessible={true}
       testID={testID}
       style={[
         styles.badge,
@@ -178,6 +179,9 @@ export const Badge = ({ text, outline = false, variant, testID }: Badge) => {
       ]}
     >
       <Text
+        accessibilityLabel={text}
+        importantForAccessibility="yes"
+        accessibilityRole="text"
         numberOfLines={1}
         ellipsizeMode="tail"
         allowFontScaling={isExperimental}

--- a/src/components/badge/__test__/__snapshots__/badge.test.tsx.snap
+++ b/src/components/badge/__test__/__snapshots__/badge.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Test Badge Components - Experimental Enabled Badge Snapshot 1`] = `
 <View
+  accessible={true}
   style={
     [
       {
@@ -20,8 +21,11 @@ exports[`Test Badge Components - Experimental Enabled Badge Snapshot 1`] = `
   }
 >
   <Text
+    accessibilityLabel="text"
+    accessibilityRole="text"
     allowFontScaling={true}
     ellipsizeMode="tail"
+    importantForAccessibility="yes"
     maxFontSizeMultiplier={1.25}
     numberOfLines={1}
     style={
@@ -51,6 +55,7 @@ exports[`Test Badge Components - Experimental Enabled Badge Snapshot 1`] = `
 
 exports[`Test Badge Components Badge Snapshot 1`] = `
 <View
+  accessible={true}
   style={
     [
       {
@@ -69,8 +74,11 @@ exports[`Test Badge Components Badge Snapshot 1`] = `
   }
 >
   <Text
+    accessibilityLabel="text"
+    accessibilityRole="text"
     allowFontScaling={false}
     ellipsizeMode="tail"
+    importantForAccessibility="yes"
     maxFontSizeMultiplier={1.25}
     numberOfLines={1}
     style={

--- a/src/components/listitems/ListItemInfo.tsx
+++ b/src/components/listitems/ListItemInfo.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentProps, useCallback, useMemo } from "react";
-import { View } from "react-native";
+import { Platform, View } from "react-native";
 import {
   IOListItemStyles,
   IOListItemVisualParams,
@@ -81,17 +81,7 @@ export const ListItemInfo = ({
 
   const itemInfoTextComponent = useMemo(
     () => (
-      <View
-        accessible={endElement === undefined ? true : false}
-        importantForAccessibility={
-          endElement !== undefined && endElement.type !== "badge"
-            ? "no-hide-descendants"
-            : "yes"
-        }
-        accessibilityElementsHidden={
-          endElement !== undefined && endElement.type !== "badge"
-        }
-      >
+      <View accessible={Platform.OS === "ios"}>
         <LabelSmall weight="Regular" color={theme["textBody-tertiary"]}>
           {label}
         </LabelSmall>
@@ -104,7 +94,7 @@ export const ListItemInfo = ({
         )}
       </View>
     ),
-    [label, value, numberOfLines, theme, endElement]
+    [label, value, numberOfLines, theme]
   );
 
   const listItemInfoAction = useCallback(() => {
@@ -113,7 +103,9 @@ export const ListItemInfo = ({
 
       switch (type) {
         case "buttonLink":
-          const buttonLinkAccessibilityLabel = `${listItemAccessibilityLabel}; ${componentProps.accessibilityLabel}`;
+          const buttonLinkAccessibilityLabel = `${
+            componentProps.accessibilityLabel ?? componentProps.label
+          }`;
 
           return (
             <ButtonLink
@@ -122,7 +114,7 @@ export const ListItemInfo = ({
             />
           );
         case "iconButton":
-          const iconButtonAccessibilityLabel = `${listItemAccessibilityLabel}; ${componentProps.accessibilityLabel}`;
+          const iconButtonAccessibilityLabel = `${componentProps.accessibilityLabel}`;
           return (
             <IconButton
               {...componentProps}
@@ -136,7 +128,7 @@ export const ListItemInfo = ({
       }
     }
     return <></>;
-  }, [endElement, listItemAccessibilityLabel]);
+  }, [endElement]);
 
   return (
     <View

--- a/src/components/listitems/__test__/__snapshots__/listitem.test.tsx.snap
+++ b/src/components/listitems/__test__/__snapshots__/listitem.test.tsx.snap
@@ -234,9 +234,7 @@ exports[`Test List Item Components - Experimental Enabled  ListItemInfo Snapshot
       }
     >
       <View
-        accessibilityElementsHidden={false}
         accessible={true}
-        importantForAccessibility="yes"
       >
         <Text
           allowFontScaling={true}
@@ -2065,9 +2063,7 @@ exports[`Test List Item Components ListItemInfo Snapshot 1`] = `
       }
     >
       <View
-        accessibilityElementsHidden={false}
         accessible={true}
-        importantForAccessibility="yes"
       >
         <Text
           allowFontScaling={false}


### PR DESCRIPTION
## Short description
In this PR, the accessibility of the ListItem component has been improved, as well as the Badge component, which previously lacked accessibility handling.

## Demo

<p>

| 🍏 A11Y iOS 🍏 | 🤖 A11Y Android 🤖 | 
| - | - |
| <video src="https://github.com/user-attachments/assets/a5d1ea0c-9567-40e5-a200-316201b6dd6c" /> | <video src="https://github.com/user-attachments/assets/9502b734-d2d7-4482-88b7-f903d92ce5c8" />  |

</p>

## How to test
To test this functionality, you can try out the components in the test app.