### PR TITLE
feat: [PE-680] Change purple badge colors

### DIFF
--- a/src/components/badge/Badge.tsx
+++ b/src/components/badge/Badge.tsx
@@ -101,7 +101,7 @@ export const Badge = ({ text, outline = false, variant, testID }: Badge) => {
       background: "error-100"
     },
     purple: {
-      foreground: "hanPurple-850",
+      foreground: "hanPurple-500",
       background: "hanPurple-100"
     },
     lightBlue: {
@@ -142,7 +142,7 @@ export const Badge = ({ text, outline = false, variant, testID }: Badge) => {
       foreground: "error-850"
     },
     purple: {
-      foreground: "hanPurple-850"
+      foreground: "hanPurple-500"
     },
     lightBlue: {
       foreground: "blueIO-850"


### PR DESCRIPTION
## Short description
Change badge purple variant color
See https://pagopa.atlassian.net/browse/PE-680 for changes details

## List of changes proposed in this pull request
- changed color

## How to test
- Login into app
- Go to CGN card trough wallet (add it to wallet if needed)
- "discover opportunities"
- select a catagery
- select a merchant
- the badge colors should be of a clearer purple color (it was so dark that it looked black before)
