### PR TITLE
[IOAPPX-398] Add dark mode compatibility to `HeaderSecondLevel`

### DIFF
--- a/example/src/navigation/navigator.tsx
+++ b/example/src/navigation/navigator.tsx
@@ -49,7 +49,7 @@ import { Sandbox } from "../pages/Sandbox";
 import { SearchCustom } from "../pages/SearchCustom";
 import { SearchNative } from "../pages/SearchNative";
 import { Selection } from "../pages/Selection";
-import { StaticHeaderSecondLevelScreen } from "../pages/StaticHeaderSecondLevel";
+import { HeaderSecondLevelScreenStatic } from "../pages/StaticHeaderSecondLevel";
 import { StepperPage } from "../pages/Stepper";
 import { TabNavigationScreen } from "../pages/TabNavigation";
 import { TextInputs } from "../pages/TextInputs";
@@ -401,7 +401,7 @@ const AppNavigator = () => {
 
           <Stack.Screen
             name={APP_ROUTES.COMPONENTS.HEADER_SECOND_LEVEL_STATIC.route}
-            component={StaticHeaderSecondLevelScreen}
+            component={HeaderSecondLevelScreenStatic}
             options={{
               headerTitle:
                 APP_ROUTES.COMPONENTS.HEADER_SECOND_LEVEL_STATIC.title,

--- a/example/src/pages/HeaderSecondLevel.tsx
+++ b/example/src/pages/HeaderSecondLevel.tsx
@@ -1,12 +1,3 @@
-import * as React from "react";
-import { useState } from "react";
-import { Alert, View, LayoutChangeEvent } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import Animated, {
-  useAnimatedScrollHandler,
-  useSharedValue
-} from "react-native-reanimated";
-import { useNavigation } from "@react-navigation/native";
 import {
   AlertEdgeToEdgeProps,
   Body,
@@ -17,9 +8,19 @@ import {
   HeaderSecondLevel,
   HStack,
   IOVisualCostants,
+  useIOTheme,
   VSpacer,
   VStack
 } from "@pagopa/io-app-design-system";
+import { useNavigation } from "@react-navigation/native";
+import * as React from "react";
+import { useState } from "react";
+import { Alert, LayoutChangeEvent, View } from "react-native";
+import Animated, {
+  useAnimatedScrollHandler,
+  useSharedValue
+} from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { StatusBannerContext } from "../components/StatusBannerProvider";
 
 // This is defined as about the half of a default ListItem… component
@@ -53,6 +54,7 @@ export const HeaderSecondLevelScreen = () => {
 
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
+  const theme = useIOTheme();
 
   const getTitleHeight = (event: LayoutChangeEvent) => {
     const { height } = event.nativeEvent.layout;
@@ -122,7 +124,9 @@ export const HeaderSecondLevelScreen = () => {
         onLayout={getTitleHeight}
         // style={{ backgroundColor: IOColors["hanPurple-500"] }}
       >
-        <H3>Questo è un titolo lungo, ma lungo lungo davvero, eh!</H3>
+        <H3 color={theme["textHeading-default"]}>
+          Questo è un titolo lungo, ma lungo lungo davvero, eh!
+        </H3>
       </View>
       <VSpacer />
       {["info", "warning", "error"].map(variant => (

--- a/example/src/pages/HeaderSecondLevelDiscreteTransition.tsx
+++ b/example/src/pages/HeaderSecondLevelDiscreteTransition.tsx
@@ -3,6 +3,7 @@ import {
   H3,
   HeaderSecondLevel,
   IOVisualCostants,
+  useIOTheme,
   VSpacer
 } from "@pagopa/io-app-design-system";
 import { useNavigation } from "@react-navigation/native";
@@ -15,6 +16,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 export const HeaderSecondLevelScreenDiscreteTransition = () => {
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
+  const theme = useIOTheme();
 
   const animatedScrollViewRef = useAnimatedRef<Animated.ScrollView>();
 
@@ -63,7 +65,9 @@ export const HeaderSecondLevelScreenDiscreteTransition = () => {
       }}
       scrollEventThrottle={8}
     >
-      <H3>Questo è un titolo lungo, ma lungo lungo davvero, eh!</H3>
+      <H3 color={theme["textHeading-default"]}>
+        Questo è un titolo lungo, ma lungo lungo davvero, eh!
+      </H3>
       <VSpacer />
       {[...Array(50)].map((_el, i) => (
         <Body key={`body-${i}`}>Repeated text</Body>

--- a/example/src/pages/HeaderSecondLevelForModal.tsx
+++ b/example/src/pages/HeaderSecondLevelForModal.tsx
@@ -12,6 +12,7 @@ import {
   H3,
   HeaderSecondLevel,
   IOVisualCostants,
+  useIOTheme,
   VSpacer
 } from "@pagopa/io-app-design-system";
 
@@ -26,6 +27,7 @@ export const HeaderSecondLevelScreen = () => {
 
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
+  const theme = useIOTheme();
 
   const getTitleHeight = (event: LayoutChangeEvent) => {
     const { height } = event.nativeEvent.layout;
@@ -94,7 +96,9 @@ export const HeaderSecondLevelScreen = () => {
         onLayout={getTitleHeight}
         // style={{ backgroundColor: IOColors["hanPurple-500"] }}
       >
-        <H3>Questo è un titolo lungo, ma lungo lungo davvero, eh!</H3>
+        <H3 color={theme["textHeading-default"]}>
+          Questo è un titolo lungo, ma lungo lungo davvero, eh!
+        </H3>
       </View>
       <VSpacer />
       {[...Array(50)].map((_el, i) => (

--- a/example/src/pages/HeaderSecondLevelWithStepper.tsx
+++ b/example/src/pages/HeaderSecondLevelWithStepper.tsx
@@ -13,6 +13,7 @@ import {
   HeaderSecondLevel,
   IOVisualCostants,
   Stepper,
+  useIOTheme,
   VSpacer
 } from "@pagopa/io-app-design-system";
 
@@ -27,6 +28,7 @@ export const HeaderSecondLevelWithStepper = () => {
 
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
+  const theme = useIOTheme();
 
   const getTitleHeight = (event: LayoutChangeEvent) => {
     const { height } = event.nativeEvent.layout;
@@ -74,7 +76,9 @@ export const HeaderSecondLevelWithStepper = () => {
       decelerationRate="normal"
     >
       <View onLayout={getTitleHeight}>
-        <H3>Questo è un titolo lungo, ma lungo lungo davvero, eh!</H3>
+        <H3 color={theme["textHeading-default"]}>
+          Questo è un titolo lungo, ma lungo lungo davvero, eh!
+        </H3>
       </View>
       <VSpacer />
       {[...Array(50)].map((_el, i) => (

--- a/example/src/pages/StaticHeaderSecondLevel.tsx
+++ b/example/src/pages/StaticHeaderSecondLevel.tsx
@@ -12,13 +12,14 @@ import {
   H3,
   HeaderSecondLevel,
   IOVisualCostants,
+  useIOTheme,
   VSpacer
 } from "@pagopa/io-app-design-system";
 
 // This is defined as about the half of a default ListItem… component
 const defaultTriggerOffsetValue: number = 32;
 
-export const StaticHeaderSecondLevelScreen = () => {
+export const HeaderSecondLevelScreenStatic = () => {
   const [triggerOffsetValue, setTriggerOffsetValue] = useState(
     defaultTriggerOffsetValue
   );
@@ -26,6 +27,7 @@ export const StaticHeaderSecondLevelScreen = () => {
 
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
+  const theme = useIOTheme();
 
   const getTitleHeight = (event: LayoutChangeEvent) => {
     const { height } = event.nativeEvent.layout;
@@ -77,7 +79,9 @@ export const StaticHeaderSecondLevelScreen = () => {
       decelerationRate="normal"
     >
       <View onLayout={getTitleHeight}>
-        <H3>Questo è un titolo lungo, ma lungo lungo davvero, eh!</H3>
+        <H3 color={theme["textHeading-default"]}>
+          Questo è un titolo lungo, ma lungo lungo davvero, eh!
+        </H3>
       </View>
       <VSpacer />
       {[...Array(50)].map((_el, i) => (

--- a/src/components/layout/HeaderSecondLevel.tsx
+++ b/src/components/layout/HeaderSecondLevel.tsx
@@ -30,7 +30,8 @@ import {
   hexToRgba,
   iconBtnSizeSmall,
   useIOExperimentalDesign,
-  useIOTheme
+  useIOTheme,
+  useIOThemeContext
 } from "../../core";
 import type { IOSpacer, IOSpacingScale } from "../../core/IOSpacing";
 import { makeFontStyleObject } from "../../utils/fonts";
@@ -166,19 +167,24 @@ export const HeaderSecondLevel = ({
 
   const { isExperimental } = useIOExperimentalDesign();
   const theme = useIOTheme();
+  const { themeType } = useIOThemeContext();
   const insets = useSafeAreaInsets();
   const isTitleAccessible = React.useMemo(() => !!title.trim(), [title]);
   const paddingTop = useSharedValue(ignoreSafeAreaMargin ? 0 : insets.top);
 
+  const iconButtonColorDefault: ComponentProps<typeof IconButton>["color"] =
+    themeType === "dark" ? "contrast" : "neutral";
+
   const iconButtonColor: ComponentProps<typeof IconButton>["color"] =
-    variant === "neutral" ? "neutral" : "contrast";
+    variant === "contrast" ? "contrast" : iconButtonColorDefault;
+
   const titleColor: ColorValue =
     variant === "neutral"
       ? IOColors[theme["textHeading-default"]]
       : IOColors.white;
 
   /* Visual attributes when there are transitions between states */
-  const HEADER_DEFAULT_BG_COLOR: IOColors = "white";
+  const HEADER_DEFAULT_BG_COLOR: IOColors = theme["appBackground-primary"];
 
   const headerBgColorTransparentState = backgroundColor
     ? hexToRgba(backgroundColor, 0)
@@ -189,10 +195,12 @@ export const HeaderSecondLevel = ({
   const headerBgColorSolidState =
     backgroundColor ?? IOColors[HEADER_DEFAULT_BG_COLOR];
 
+  const borderColorDefault = IOColors[theme["divider-default"]];
+
   const borderColorTransparentState = backgroundColor
     ? hexToRgba(backgroundColor, 0)
-    : hexToRgba(IOColors["grey-100"], 0);
-  const borderColorSolidState = backgroundColor ?? IOColors["grey-100"];
+    : hexToRgba(borderColorDefault, 0);
+  const borderColorSolidState = backgroundColor ?? borderColorDefault;
 
   useLayoutEffect(() => {
     if (isTitleAccessible) {

--- a/src/core/IOColors.ts
+++ b/src/core/IOColors.ts
@@ -275,6 +275,7 @@ export type IOTheme = {
   "icon-default": IOColors;
   "icon-decorative": IOColors;
   // Layout
+  "divider-header": IOColors;
   "divider-default": IOColors;
   "divider-bottomBar": IOColors;
   // Status
@@ -306,6 +307,7 @@ export const IOThemeLight: IOTheme = {
   "icon-default": "grey-650",
   "icon-decorative": "grey-300",
   // Layout
+  "divider-header": "grey-100",
   "divider-default": "grey-200",
   "divider-bottomBar": "grey-200",
   // Status
@@ -343,6 +345,7 @@ export const IOThemeDark: IOTheme = {
   "cardBorder-default": "grey-850",
   "icon-default": "grey-450",
   // Layout
+  "divider-header": "grey-850",
   "divider-default": "grey-850",
   "divider-bottomBar": "grey-850",
   // Status


### PR DESCRIPTION
## Short description
This PR adds dark mode compatibility to the `HeaderSecondLevel`

## List of changes proposed in this pull request
- Replace previous default colors with new ones based on the theme

### Preview

https://github.com/user-attachments/assets/5558dd78-beaf-4186-b09c-06681e61a28c


## How to test
Launch the example app and visit each screen related to the **Header Second Level**