### PR TITLE
[IOAPPX-402] Add full dark mode support to `ListItemTransaction`

### DIFF
--- a/src/components/listitems/ListItemTransaction.tsx
+++ b/src/components/listitems/ListItemTransaction.tsx
@@ -142,6 +142,9 @@ export const ListItemTransaction = ({
     ? theme["interactiveElem-default"]
     : "blue";
 
+  const amountColor: IOColors = theme["textBody-default"];
+  const successColor: IOColors = theme.successText;
+
   const ListItemTransactionContent = () => {
     const TransactionAmountOrBadgeComponent = () => {
       switch (transactionStatus) {
@@ -149,7 +152,7 @@ export const ListItemTransaction = ({
           return (
             <H6
               accessibilityLabel={getAccessibleAmountText(transactionAmount)}
-              color={hasChevronRight ? interactiveColor : "black"}
+              color={hasChevronRight ? interactiveColor : amountColor}
               numberOfLines={numberOfLines}
             >
               {transactionAmount || ""}
@@ -159,7 +162,7 @@ export const ListItemTransaction = ({
           return (
             <H6
               accessibilityLabel={getAccessibleAmountText(transactionAmount)}
-              color={hasChevronRight ? interactiveColor : "success-700"}
+              color={hasChevronRight ? interactiveColor : successColor}
               numberOfLines={numberOfLines}
             >
               {transactionAmount || ""}

--- a/src/core/IOColors.ts
+++ b/src/core/IOColors.ts
@@ -281,6 +281,7 @@ export type IOTheme = {
   // Status
   errorIcon: IOColors;
   errorText: IOColors;
+  successText: IOColors;
   // Pictograms
   "pictogram-hands": IOColors;
   "pictogram-tint-main": IOColors;
@@ -313,6 +314,7 @@ export const IOThemeLight: IOTheme = {
   // Status
   errorIcon: "error-600",
   errorText: "error-600",
+  successText: "success-700",
   // Pictograms
   "pictogram-hands": "blueIO-500",
   "pictogram-tint-main": "turquoise-150",
@@ -351,6 +353,7 @@ export const IOThemeDark: IOTheme = {
   // Status
   errorIcon: "error-400",
   errorText: "error-400",
+  successText: "success-400",
   // Pictograms
   "pictogram-hands": "white",
   "pictogram-tint-main": "turquoise-150",


### PR DESCRIPTION
## Short description
This PR adds full dark mode support to `ListItemTransaction`.

### Preview
Amount was previously rendered as black text:

<img src="https://github.com/user-attachments/assets/3f120ad3-c866-4cb7-a298-8ee1163ee9a0" width="320" />

## How to test
Enable **Dark mode** on the **List Items** page of the example app