### PR TITLE
Add `accessibiltyRole` to `ListItemInfo` component

### DIFF
--- a/src/components/listitems/ListItemInfo.tsx
+++ b/src/components/listitems/ListItemInfo.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentProps, useCallback, useMemo } from "react";
-import { Platform, View } from "react-native";
+import { AccessibilityRole, Platform, View } from "react-native";
 import {
   IOListItemStyles,
   IOListItemVisualParams,
@@ -7,12 +7,12 @@ import {
   useIOTheme
 } from "../../core";
 import { WithTestID } from "../../utils/types";
-import { IOIconSizeScale, IOIcons, Icon } from "../icons";
-import { H6, LabelSmall } from "../typography";
-import { ButtonLink, IconButton } from "../buttons";
 import { Badge } from "../badge";
+import { ButtonLink, IconButton } from "../buttons";
 import { LogoPaymentWithFallback } from "../common/LogoPaymentWithFallback";
+import { IOIconSizeScale, IOIcons, Icon } from "../icons";
 import { IOLogoPaymentType } from "../logos";
+import { H6, LabelSmall } from "../typography";
 
 type ButtonLinkActionProps = {
   type: "buttonLink";
@@ -41,6 +41,7 @@ export type ListItemInfo = WithTestID<{
   endElement?: EndElementProps;
   // Accessibility
   accessibilityLabel?: string;
+  accessibilityRole?: AccessibilityRole;
 }> &
   (
     | {
@@ -63,6 +64,7 @@ export const ListItemInfo = ({
   paymentLogoIcon,
   endElement,
   accessibilityLabel,
+  accessibilityRole,
   testID
 }: ListItemInfo) => {
   const theme = useIOTheme();
@@ -136,6 +138,7 @@ export const ListItemInfo = ({
       testID={testID}
       accessible={endElement === undefined ? true : false}
       accessibilityLabel={listItemAccessibilityLabel}
+      accessibilityRole={accessibilityRole}
     >
       <View style={IOListItemStyles.listItemInner}>
         {icon && (


### PR DESCRIPTION
## Short description
This PR introduces the accessibilityRole prop to the ListItemInfo component, enabling better support for accessibilty when displaying non-string values.

## List of changes proposed in this pull request
- Added `accessibiltyRole` prop to `ListItemInfo` component

## How to test
1. Set the accessibilityRole prop on a ListItemInfo component.
2. Verify that screen readers correctly interpret the role specified by the prop, ensuring accessibility is enhanced as expected.
