### PR TITLE
Remove `HeaderSecondLevel` background opacity animation if `transparent: false`

### DIFF
--- a/example/src/pages/HeaderSecondLevelCustomBackground.tsx
+++ b/example/src/pages/HeaderSecondLevelCustomBackground.tsx
@@ -42,7 +42,6 @@ export const HeaderSecondLevelCustomBackground = () => {
 
   React.useLayoutEffect(() => {
     navigation.setOptions({
-      headerTransparent: true,
       header: () => (
         <HeaderSecondLevel
           scrollValues={{
@@ -52,7 +51,6 @@ export const HeaderSecondLevelCustomBackground = () => {
           title={"Questo è un titolo lungo, ma lungo lungo davvero, eh!"}
           goBack={() => navigation.goBack()}
           backAccessibilityLabel="Torna indietro"
-          transparent={true}
           variant="contrast"
           backgroundColor={IOColors["blueIO-500"]}
           type="threeActions"
@@ -97,7 +95,7 @@ export const HeaderSecondLevelCustomBackground = () => {
     >
       <View
         style={{
-          backgroundColor: IOColors["blueIO-600"],
+          backgroundColor: IOColors["blueIO-500"],
           height: 400,
           position: "absolute",
           top: -400 + headerHeight + triggerOffsetValue * 2,

--- a/src/components/layout/HeaderSecondLevel.tsx
+++ b/src/components/layout/HeaderSecondLevel.tsx
@@ -178,21 +178,18 @@ export const HeaderSecondLevel = ({
   /* Visual attributes when there are transitions between states */
   const HEADER_DEFAULT_BG_COLOR: IOColors = theme["appBackground-primary"];
 
-  const headerBgColorTransparentState = backgroundColor
-    ? hexToRgba(backgroundColor, 0)
-    : transparent
-    ? hexToRgba(IOColors[HEADER_DEFAULT_BG_COLOR], 0)
-    : IOColors[HEADER_DEFAULT_BG_COLOR];
-
   const headerBgColorSolidState =
     backgroundColor ?? IOColors[HEADER_DEFAULT_BG_COLOR];
 
+  const headerBgColorTransparentState = transparent
+    ? hexToRgba(headerBgColorSolidState, 0)
+    : headerBgColorSolidState;
+
   const borderColorDefault = IOColors[theme["divider-default"]];
 
-  const borderColorTransparentState = backgroundColor
-    ? hexToRgba(backgroundColor, 0)
-    : hexToRgba(borderColorDefault, 0);
   const borderColorSolidState = backgroundColor ?? borderColorDefault;
+
+  const borderColorTransparentState = hexToRgba(borderColorSolidState, 0);
 
   useLayoutEffect(() => {
     if (isTitleAccessible) {


### PR DESCRIPTION
## Short description
This PR removes the background opacity animation in `HeaderSecondLevel` component if the `transparent` prop is set to `false`

## List of changes proposed in this pull request
- set `headerBgColorTransparentState` color opacity only if `transparent` prop is set to `true`

## How to test
Open the example app, check that the `HeaderSecondLevel` behaves as expected in every use case.
