### PR TITLE
[IOAPPX-427] Fix `CodeInput` wrong empty colour when we're using dark or accent backgrounds

### DIFF
--- a/example/src/pages/NumberPad.tsx
+++ b/example/src/pages/NumberPad.tsx
@@ -43,7 +43,7 @@ export const NumberPadScreen = () => {
       headerStyle: {
         backgroundColor: blueBackground
           ? IOColors[theme["appBackground-accent"]]
-          : IOColors.white
+          : IOColors[theme["appBackground-primary"]]
       }
     });
   }, [blueBackground, navigation, theme]);
@@ -55,7 +55,7 @@ export const NumberPadScreen = () => {
         paddingVertical: IOVisualCostants.appMarginDefault,
         backgroundColor: blueBackground
           ? IOColors[theme["appBackground-accent"]]
-          : IOColors.white
+          : IOColors[theme["appBackground-primary"]]
       }}
     >
       <ContentWrapper>

--- a/src/components/codeInput/CodeInput.tsx
+++ b/src/components/codeInput/CodeInput.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useMemo } from "react";
-import { StyleSheet, View } from "react-native";
+import React, { useEffect, useState } from "react";
+import { ColorValue, StyleSheet, View } from "react-native";
 import Animated from "react-native-reanimated";
-import { IOColors, IOStyles } from "../../core";
+import { hexToRgba, IOColors, useIOThemeContext } from "../../core";
 import { triggerHaptic } from "../../functions";
 import { useErrorShakeAnimation } from "../../utils/hooks/useErrorShakeAnimation";
 import { HStack } from "../stack";
@@ -20,25 +20,26 @@ const styles = StyleSheet.create({
   dotShape: {
     width: DOT_SIZE,
     height: DOT_SIZE,
-    borderRadius: 8,
+    borderRadius: DOT_SIZE / 2,
     borderWidth: 2
-  },
-  dotEmpty: {
-    borderColor: IOColors["grey-650"]
-  },
-  wrapper: {
-    justifyContent: "center"
   }
 });
 
-const EmptyDot = () => <View style={[styles.dotShape, styles.dotEmpty]} />;
-
-const FilletDot = ({ color }: { color: IOColors }) => (
+const EmptyDot = ({ color: borderColor }: { color: ColorValue }) => (
   <View
     style={[
       styles.dotShape,
-      { backgroundColor: IOColors[color], borderColor: IOColors[color] }
+      {
+        borderColor,
+        backgroundColor: hexToRgba(borderColor, 0)
+      }
     ]}
+  />
+);
+
+const FilledDot = ({ color: backgroundColor }: { color: ColorValue }) => (
+  <View
+    style={[styles.dotShape, { backgroundColor, borderColor: backgroundColor }]}
   />
 );
 
@@ -49,19 +50,34 @@ export const CodeInput = ({
   variant = "light",
   onValidate
 }: CodeInputProps) => {
-  const [status, setStatus] = React.useState<"default" | "error">("default");
+  const [status, setStatus] = useState<"default" | "error">("default");
+  const { themeType } = useIOThemeContext();
 
   const { translate, animatedStyle, shakeAnimation } = useErrorShakeAnimation();
 
-  const fillColor = useMemo(
-    () =>
-      status === "error"
-        ? "error-600"
-        : variant === "light"
-        ? "white"
-        : "black",
-    [variant, status]
-  );
+  /* Empty Dot
+  - Right color depending on both theme and variant */
+  const emptyDotColorLightBg = IOColors["grey-650"];
+  const emptyDotColorDarkBg = hexToRgba(IOColors.white, 0.75);
+  const emptyDotColorThemeBased =
+    themeType === "light" ? emptyDotColorLightBg : emptyDotColorDarkBg;
+
+  const emptyDotColor =
+    variant === "light" ? emptyDotColorDarkBg : emptyDotColorThemeBased;
+
+  /* Filled Dot
+  - Right color depending on theme, variant and status */
+  const filledDotColorLightBg = IOColors.black;
+  const filledDotColorDarkBg = IOColors.white;
+  const filledDotColorThemeBased =
+    themeType === "light" ? filledDotColorLightBg : filledDotColorDarkBg;
+
+  const filledDotColor =
+    status === "error"
+      ? IOColors["error-600"]
+      : variant === "light"
+      ? filledDotColorDarkBg
+      : filledDotColorThemeBased;
 
   useEffect(() => {
     if (onValidate && value.length === length) {
@@ -85,13 +101,20 @@ export const CodeInput = ({
   }, [value, onValidate, length, onValueChange, translate, shakeAnimation]);
 
   return (
-    <Animated.View style={[IOStyles.row, styles.wrapper, animatedStyle]}>
+    <Animated.View
+      style={[
+        { flexDirection: "row", justifyContent: "center" },
+        animatedStyle
+      ]}
+    >
       <HStack space={DOT_SIZE}>
-        {[...Array(length)].map((_, i) => (
-          <React.Fragment key={i}>
-            {value[i] ? <FilletDot color={fillColor} /> : <EmptyDot />}
-          </React.Fragment>
-        ))}
+        {[...Array(length)].map((_, i) =>
+          value[i] ? (
+            <FilledDot key={i} color={filledDotColor} />
+          ) : (
+            <EmptyDot key={i} color={emptyDotColor} />
+          )
+        )}
       </HStack>
     </Animated.View>
   );


### PR DESCRIPTION
## Short description
This PR fixes a visual regression introduced when [we increased the contrast of the `CodeInput` component](https://github.com/pagopa/io-app-design-system/pull/341).

## List of changes proposed in this pull request
- Change the color of the empty dot when we're using dark or accent backgrounds
- Make `CodeInput` dark mode compliant

### Preview

https://github.com/user-attachments/assets/d436578e-98a7-4d5a-af7a-c45950bcecaa



## How to test
Go to the **Number Pad** screen in the example app. Enable/disable accent background or enable/disable dark mode.