### PR TITLE
[IOAPPX-438] Relax the TS constraints of `IOText` to accept any numeric value as `size`

### DIFF
--- a/src/components/typography/IOText.tsx
+++ b/src/components/typography/IOText.tsx
@@ -10,7 +10,6 @@ import { IOColors, useIOExperimentalDesign, useIOTheme } from "../../core";
 import { useBoldTextEnabled } from "../../utils/accessibility";
 import {
   IOFontFamily,
-  IOFontSize,
   IOFontWeight,
   makeFontStyleObject
 } from "../../utils/fonts";
@@ -37,7 +36,7 @@ export type TypographicStyleProps = Omit<
  * cannot be included in the default StyleProp<TextStyle>
  */
 type IOTextBaseProps = {
-  size?: IOFontSize;
+  size?: number;
   weight?: IOFontWeight;
   color?: IOColors;
   font?: IOFontFamily;

--- a/src/utils/fonts.ts
+++ b/src/utils/fonts.ts
@@ -73,7 +73,7 @@ export const fontWeights: Record<IOFontWeight, IOFontWeightNumeric> = {
 };
 
 type FontStyleObject = {
-  fontSize: IOFontSize;
+  fontSize: IOFontSize | number;
   /* We also accept `string` because Android needs a composed 
   fontFamily name, like `TitilliumSansPro-Regular` */
   fontFamily: string | IOFontFamily;
@@ -132,7 +132,7 @@ const defaultFontSize: IOFontSize = 16;
  */
 
 export const makeFontStyleObject = (
-  size: IOFontSize = defaultFontSize,
+  size: number = defaultFontSize,
   font: IOFontFamily = defaultFont,
   lineHeight: TextStyle["lineHeight"],
   weight: IOFontWeight = defaultWeight,


### PR DESCRIPTION
## Short description
This PR removes the TS constraints of the `size` property of the `IOText` component. It now accepts any numeric value.

## List of changes proposed in this pull request
- Change `IOText` TS requirements

## How to test
N/A