### PR TITLE
[IOAPPX-443] Restore `a11y` props in the `Banner` component

### DIFF
--- a/src/components/banner/Banner.tsx
+++ b/src/components/banner/Banner.tsx
@@ -37,7 +37,7 @@ import {
   PictogramBleed
 } from "../pictograms";
 import { VSpacer } from "../spacer";
-import { buttonTextFontSize, H6, IOText, BodySmall } from "../typography";
+import { BodySmall, buttonTextFontSize, H6, IOText } from "../typography";
 
 /* Styles */
 const sizePictogramBig: IOPictogramSizeScale = 80;
@@ -249,20 +249,27 @@ export const Banner = ({
         )}
         {action && (
           /* Disable pointer events to avoid
-                      pressed state on the button */
+             pressed state on the button */
           <View
             pointerEvents="none"
-            accessibilityElementsHidden
             importantForAccessibility="no-hide-descendants"
+            accessible={true}
+            accessibilityElementsHidden
+            accessibilityLabel={action}
+            accessibilityRole="button"
           >
             <VSpacer size={4} />
             <IOText
               font={isExperimental ? "Titillio" : "TitilliumSansPro"}
-              weight={isExperimental ? "Regular" : "Bold"}
+              weight="Semibold"
               color={colorMainButton}
               size={buttonTextFontSize}
               numberOfLines={1}
               ellipsizeMode="tail"
+              // A11y
+              accessible={false}
+              importantForAccessibility="no-hide-descendants"
+              accessibilityElementsHidden={true}
             >
               {action}
             </IOText>

--- a/src/components/banner/__test__/__snapshots__/banner.test.tsx.snap
+++ b/src/components/banner/__test__/__snapshots__/banner.test.tsx.snap
@@ -101,6 +101,9 @@ exports[`Test Banner Components - Experimental Enabled Banner Snapshot 1`] = `
       />
       <View
         accessibilityElementsHidden={true}
+        accessibilityLabel="Action text"
+        accessibilityRole="button"
+        accessible={true}
         importantForAccessibility="no-hide-descendants"
         pointerEvents="none"
       >
@@ -112,8 +115,11 @@ exports[`Test Banner Components - Experimental Enabled Banner Snapshot 1`] = `
           }
         />
         <Text
+          accessibilityElementsHidden={true}
+          accessible={false}
           allowFontScaling={true}
           ellipsizeMode="tail"
+          importantForAccessibility="no-hide-descendants"
           maxFontSizeMultiplier={1.25}
           numberOfLines={1}
           style={
@@ -124,7 +130,7 @@ exports[`Test Banner Components - Experimental Enabled Banner Snapshot 1`] = `
                 "fontFamily": "Titillio",
                 "fontSize": 16,
                 "fontStyle": "normal",
-                "fontWeight": "400",
+                "fontWeight": "600",
                 "lineHeight": undefined,
               },
             ]
@@ -374,6 +380,9 @@ exports[`Test Banner Components Banner Snapshot 1`] = `
       />
       <View
         accessibilityElementsHidden={true}
+        accessibilityLabel="Action text"
+        accessibilityRole="button"
+        accessible={true}
         importantForAccessibility="no-hide-descendants"
         pointerEvents="none"
       >
@@ -385,8 +394,11 @@ exports[`Test Banner Components Banner Snapshot 1`] = `
           }
         />
         <Text
+          accessibilityElementsHidden={true}
+          accessible={false}
           allowFontScaling={false}
           ellipsizeMode="tail"
+          importantForAccessibility="no-hide-descendants"
           maxFontSizeMultiplier={1.25}
           numberOfLines={1}
           style={
@@ -397,7 +409,7 @@ exports[`Test Banner Components Banner Snapshot 1`] = `
                 "fontFamily": "Titillium Sans Pro",
                 "fontSize": 16,
                 "fontStyle": "normal",
-                "fontWeight": "700",
+                "fontWeight": "600",
                 "lineHeight": undefined,
               },
             ]


### PR DESCRIPTION
## Short description
This PR restores `a11y` props in the `Banner` component, erroneously removed with the PR https://github.com/pagopa/io-app-design-system/pull/344