### PR TITLE
[IOAPPX-444] Remove export of `BlockButtons`

### DIFF
--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,4 +1,3 @@
-export * from "./BlockButtons";
 export * from "./FooterActions";
 export * from "./FooterActionsInline";
 export * from "./FooterWithButtons";


### PR DESCRIPTION
> [!caution]
> This PR depends on the approval of the following PR in the `io-app` repo:
> * https://github.com/pagopa/io-app/pull/6475

## Short description
This PR removes the export of `BlockButtons` while waiting for the complete removal of the legacy `FooterWithButtons`.

## How to test
N/A