### PR TITLE
[SIW-1978] Fix a11y issues of list item header and action element

### DIFF
--- a/src/components/listitems/ListItemHeader.tsx
+++ b/src/components/listitems/ListItemHeader.tsx
@@ -65,30 +65,19 @@ export const ListItemHeader = ({
   const { dynamicFontScale, spacingScaleMultiplier, hugeFontEnabled } =
     useIOFontDynamicScale();
 
-  const listItemAccessibilityLabel = useMemo(
-    () => (accessibilityLabel ? accessibilityLabel : `${label}`),
-    [label, accessibilityLabel]
-  );
-
   const itemInfoTextComponent = useMemo(
     () => (
       <View
-        accessible={endElement === undefined ? true : false}
-        importantForAccessibility={
-          endElement !== undefined && endElement.type !== "badge"
-            ? "no-hide-descendants"
-            : "yes"
-        }
-        accessibilityElementsHidden={
-          endElement !== undefined && endElement.type !== "badge"
-        }
+        accessible
+        accessibilityRole="header"
+        accessibilityLabel={accessibilityLabel ?? label}
       >
         <H6 role="heading" color={theme["textBody-tertiary"]}>
           {label}
         </H6>
       </View>
     ),
-    [label, theme, endElement]
+    [label, accessibilityLabel, theme]
   );
 
   const listItemAction = useCallback(() => {
@@ -97,21 +86,12 @@ export const ListItemHeader = ({
 
       switch (type) {
         case "buttonLink":
-          const buttonLinkAccessibilityLabel = `${listItemAccessibilityLabel}; ${componentProps.accessibilityLabel}`;
-
           return (
-            <ButtonLink
-              {...componentProps}
-              accessibilityLabel={buttonLinkAccessibilityLabel}
-            />
+            <ButtonLink {...componentProps} />
           );
-        case "iconButton":
-          const iconButtonAccessibilityLabel = `${listItemAccessibilityLabel}; ${componentProps.accessibilityLabel}`;
+        case "iconButton": 
           return (
-            <IconButton
-              {...componentProps}
-              accessibilityLabel={iconButtonAccessibilityLabel}
-            />
+            <IconButton {...componentProps} />
           );
         case "badge":
           return <Badge {...componentProps} />;
@@ -120,19 +100,14 @@ export const ListItemHeader = ({
       }
     }
     return <></>;
-  }, [endElement, listItemAccessibilityLabel]);
+  }, [endElement]);
 
   return (
     <View
       style={IOListItemStyles.listItem}
       testID={testID}
-      accessible={endElement === undefined ? true : false}
-      accessibilityLabel={listItemAccessibilityLabel}
     >
-      <View
-        style={IOListItemStyles.listItemInner}
-        importantForAccessibility={endElement ? "auto" : "no-hide-descendants"}
-      >
+      <View style={IOListItemStyles.listItemInner}>
         {iconName && !hugeFontEnabled && (
           <View
             style={{


### PR DESCRIPTION
## Short description
This PR modifies the accessibility props of `ListItemHeader` to fix how the header is announced. To be more specific:
- The header label is announced independently as a header;
- The optional action item on the right is announced with its own accessibility label, without the header label.

## List of changes proposed in this pull request
- Made the header view accessible with role header
- Removed accessibility from the outer component view
- Removed concatenation of header label and action label

## How to test
Use a screen reader to announce the list item header, with and without the end element. Ensure each part is announced correctly, in the right order.