### PR TITLE
Add `secureTextEntry` to the `OTPInput`'s `TextInput` component

### DIFF
--- a/src/components/otpInput/OTPInput.tsx
+++ b/src/components/otpInput/OTPInput.tsx
@@ -149,6 +149,7 @@ export const OTPInput = React.forwardRef<View, Props>(
             inputAccessoryViewID={inputAccessoryViewID}
             accessible={true}
             autoFocus={autoFocus}
+            secureTextEntry={true}
           />
           {[...Array(length)].map((_, i) => (
             <BoxedInput


### PR DESCRIPTION
## Short description
Added the `secureTextEntry` property to the `TextInput` of the custom `OTPInput` component to obscure the keyboard in screenshots and screen recordings, in case the component is used in a context where such protection is enabled (e.g. using `react-native-screenshot-prevent` lib).

## List of changes proposed in this pull request
- Added `secureTextEntry` prop
