### PR TITLE
refactor: `HeaderFirstLevel`'s actions prop refactoring

### DIFF
--- a/example/src/pages/HeaderFirstLevel.tsx
+++ b/example/src/pages/HeaderFirstLevel.tsx
@@ -5,6 +5,7 @@ import {
   ButtonSolid,
   H3,
   H6,
+  HeaderActionProps,
   HeaderFirstLevel,
   HStack,
   IOVisualCostants,
@@ -20,10 +21,43 @@ import { Alert, ScrollView } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { StatusBannerContext } from "../components/StatusBannerProvider";
 
+const firstAction: HeaderActionProps = {
+  icon: "help",
+  accessibilityLabel: "Go to the help section",
+  onPress: () => {
+    Alert.alert("Contextual Help");
+  }
+};
+
+const secondAction: HeaderActionProps = {
+  icon: "coggle",
+  accessibilityLabel: "Go to the Settings section",
+  onPress: () => {
+    Alert.alert("Settings");
+  }
+};
+
+const thirdAction: HeaderActionProps = {
+  icon: "light",
+  accessibilityLabel: "Turn on/off the light",
+  onPress: () => {
+    Alert.alert("Light");
+  }
+};
+
+const actionsConfiguration: {
+  [size: number]: React.ComponentProps<typeof HeaderFirstLevel>["actions"];
+} = {
+  0: [],
+  1: [firstAction],
+  2: [firstAction, secondAction],
+  3: [firstAction, secondAction, thirdAction]
+};
+
 export const HeaderFirstLevelScreen = () => {
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
-  const [actions, setActions] = useState(2);
+  const [actionsSize, setActionsSize] = useState(2);
 
   const { showAlert, removeAlert, alert } = useContext(StatusBannerContext);
 
@@ -50,43 +84,11 @@ export const HeaderFirstLevelScreen = () => {
         <HeaderFirstLevel
           ignoreSafeAreaMargin={alert !== undefined}
           title={"Pagina"}
-          firstAction={
-            actions > 0
-              ? {
-                  icon: "help",
-                  accessibilityLabel: "Go to the help section",
-                  onPress: () => {
-                    Alert.alert("Contextual Help");
-                  }
-                }
-              : undefined
-          }
-          secondAction={
-            actions > 1
-              ? {
-                  icon: "coggle",
-                  accessibilityLabel: "Go to the Settings section",
-                  onPress: () => {
-                    Alert.alert("Settings");
-                  }
-                }
-              : undefined
-          }
-          thirdAction={
-            actions > 2
-              ? {
-                  icon: "light",
-                  accessibilityLabel: "Turn on/off the light",
-                  onPress: () => {
-                    Alert.alert("Light");
-                  }
-                }
-              : undefined
-          }
+          actions={actionsConfiguration[actionsSize]}
         />
       )
     });
-  }, [navigation, alert, actions]);
+  }, [navigation, alert, actionsSize]);
 
   return (
     <ScrollView
@@ -99,14 +101,26 @@ export const HeaderFirstLevelScreen = () => {
       <H3>Questo è un titolo lungo, ma lungo lungo davvero, eh!</H3>
       <VSpacer />
       <ListItemHeader label="Header actions size" />
-      {Array.from({ length: 4 }).map((_, i) => (
-        <ListItemRadio
-          key={i}
-          value={`${i} actions`}
-          selected={i === actions}
-          onValueChange={() => setActions(i)}
-        />
-      ))}
+      <ListItemRadio
+        value="No actions"
+        selected={actionsSize === 0}
+        onValueChange={() => setActionsSize(0)}
+      />
+      <ListItemRadio
+        value="One action"
+        selected={actionsSize === 1}
+        onValueChange={() => setActionsSize(1)}
+      />
+      <ListItemRadio
+        value="Two actions"
+        selected={actionsSize === 2}
+        onValueChange={() => setActionsSize(2)}
+      />
+      <ListItemRadio
+        value="Three actions"
+        selected={actionsSize === 3}
+        onValueChange={() => setActionsSize(3)}
+      />
       <VSpacer />
       <ButtonSolid
         label="Torna indietro"

--- a/src/components/layout/HeaderFirstLevel.tsx
+++ b/src/components/layout/HeaderFirstLevel.tsx
@@ -26,11 +26,15 @@ import { HStack } from "../stack";
 import { H3 } from "../typography";
 import { HeaderActionProps } from "./common";
 
+type HeaderActionsProp =
+  | readonly [] // No actions
+  | readonly [HeaderActionProps] // Single action
+  | readonly [HeaderActionProps, HeaderActionProps] // Two actions
+  | readonly [HeaderActionProps, HeaderActionProps, HeaderActionProps]; // Three actions
+
 export type HeaderFirstLevel = WithTestID<{
   title: string;
-  firstAction?: HeaderActionProps;
-  secondAction?: HeaderActionProps;
-  thirdAction?: HeaderActionProps;
+  actions: HeaderActionsProp;
   animatedRef?: AnimatedRef<Animated.ScrollView>;
   animatedFlatListRef?: AnimatedRef<Animated.FlatList<any>>;
   ignoreSafeAreaMargin?: boolean;
@@ -58,9 +62,7 @@ const styles = StyleSheet.create({
 export const HeaderFirstLevel = ({
   title,
   testID,
-  firstAction,
-  secondAction,
-  thirdAction,
+  actions = [],
   ignoreSafeAreaMargin = false,
   animatedRef,
   animatedFlatListRef
@@ -133,9 +135,9 @@ export const HeaderFirstLevel = ({
           </H3>
         </View>
         <HStack space={16} style={{ flexShrink: 0 }}>
-          {thirdAction && <IconButton {...thirdAction} color={"primary"} />}
-          {secondAction && <IconButton {...secondAction} color={"primary"} />}
-          {firstAction && <IconButton {...firstAction} color={"primary"} />}
+          {actions.map((action, index) => (
+            <IconButton key={index} {...action} color={"primary"} />
+          ))}
         </HStack>
       </View>
     </Animated.View>

--- a/src/components/layout/HeaderFirstLevel.tsx
+++ b/src/components/layout/HeaderFirstLevel.tsx
@@ -136,7 +136,11 @@ export const HeaderFirstLevel = ({
         </View>
         <HStack space={16} style={{ flexShrink: 0 }}>
           {actions.map((action, index) => (
-            <IconButton key={index} {...action} color={"primary"} />
+            <IconButton
+              key={`header-first-level-action-${index}`}
+              {...action}
+              color={"primary"}
+            />
           ))}
         </HStack>
       </View>

--- a/stories/foundation/templates/HeaderFirstLevel.stories.ts
+++ b/stories/foundation/templates/HeaderFirstLevel.stories.ts
@@ -23,31 +23,35 @@ type Story = StoryObj<typeof meta>;
 export const Wallet: Story = {
   args: {
     title: "Portafoglio",
-    firstAction: {
-      icon: "help",
-      accessibilityLabel: "Help",
-      onPress: () => alert("First Action")
-    },
-    secondAction: {
-      icon: "add",
-      onPress: () => alert("Second Action"),
-      accessibilityLabel: "Add"
-    }
+    actions: [
+      {
+        icon: "add",
+        onPress: () => alert("Second Action"),
+        accessibilityLabel: "Add"
+      },
+      {
+        icon: "help",
+        accessibilityLabel: "Help",
+        onPress: () => alert("First Action")
+      }
+    ]
   }
 };
 
 export const Messages: Story = {
   args: {
     title: "Messaggi",
-    firstAction: {
-      icon: "help",
-      accessibilityLabel: "Help",
-      onPress: () => alert("First Action")
-    },
-    secondAction: {
-      icon: "search",
-      onPress: () => alert("Second Action"),
-      accessibilityLabel: "search"
-    }
+    actions: [
+      {
+        icon: "search",
+        onPress: () => alert("Second Action"),
+        accessibilityLabel: "search"
+      },
+      {
+        icon: "help",
+        accessibilityLabel: "Help",
+        onPress: () => alert("First Action")
+      }
+    ]
   }
 };


### PR DESCRIPTION
## Short description
This PR refactors `HeaderFirstLevel`'s actions props with a dynamic type which allows to configure 0 to 3 actions.

## List of changes proposed in this pull request
- Replaced `firstAction`, `secondAction` and `thirdAction` with `actions`

## How to test
Run the example app and go to the **Header First Level** page, test the header with different action configurations
