### PR TITLE
fix: [IOAPPX-478] Fix `HeaderSecondLevel` issue when variant is set explicitly and dark mode is enabled

### DIFF
--- a/example/src/pages/Buttons.tsx
+++ b/example/src/pages/Buttons.tsx
@@ -12,6 +12,7 @@ import {
   IconButtonSolid,
   ListItemSwitch,
   VSpacer,
+  hexToRgba,
   useIOExperimentalDesign
 } from "@pagopa/io-app-design-system";
 import React, { useState } from "react";
@@ -27,6 +28,13 @@ const styles = StyleSheet.create({
   },
   primaryBlock: {
     backgroundColor: IOColors["blueIO-500"],
+    padding: 16,
+    borderRadius: 16
+  },
+  neutralBlock: {
+    borderWidth: 1,
+    borderColor: hexToRgba(IOColors.black, 0.1),
+    backgroundColor: IOColors.white,
     padding: 16,
     borderRadius: 16
   }
@@ -688,6 +696,49 @@ export const Buttons = () => {
 
             <IconButton
               color="contrast"
+              accessibilityLabel="Help"
+              accessibilityHint="Tap to trigger test alert"
+              icon="help"
+              disabled
+              onPress={onButtonPress}
+            />
+          </View>
+        </ComponentViewerBox>
+      </View>
+
+      <VSpacer />
+
+      <View style={styles.neutralBlock}>
+        <ComponentViewerBox
+          name="IconButton · Neutral variant, persistent color mode"
+          last
+        >
+          <View style={IOStyles.row}>
+            <IconButton
+              persistentColorMode
+              color="neutral"
+              accessibilityLabel="Search"
+              accessibilityHint="Tap to trigger test alert"
+              icon="search"
+              onPress={onButtonPress}
+            />
+
+            <HSpacer size={16} />
+
+            <IconButton
+              persistentColorMode
+              color="neutral"
+              accessibilityLabel="Help"
+              accessibilityHint="Tap to trigger test alert"
+              icon="help"
+              onPress={onButtonPress}
+            />
+
+            <HSpacer size={16} />
+
+            <IconButton
+              persistentColorMode
+              color="neutral"
               accessibilityLabel="Help"
               accessibilityHint="Tap to trigger test alert"
               icon="help"

--- a/example/src/pages/HeaderSecondLevelScreenDiscreteTransitionCustomBg.tsx
+++ b/example/src/pages/HeaderSecondLevelScreenDiscreteTransitionCustomBg.tsx
@@ -6,8 +6,8 @@ import {
   IOVisualCostants,
   VSpacer
 } from "@pagopa/io-app-design-system";
-import { useNavigation } from "@react-navigation/native";
 import { useHeaderHeight } from "@react-navigation/elements";
+import { useNavigation } from "@react-navigation/native";
 import * as React from "react";
 import { useLayoutEffect } from "react";
 import { Alert, View } from "react-native";
@@ -23,13 +23,11 @@ export const HeaderSecondLevelScreenDiscreteTransitionCustomBg = () => {
 
   useLayoutEffect(() => {
     navigation.setOptions({
-      headerTransparent: true,
       header: () => (
         <HeaderSecondLevel
           enableDiscreteTransition
-          transparent
-          variant="contrast"
-          backgroundColor={IOColors["blueIO-500"]}
+          variant="neutral"
+          backgroundColor={IOColors["blueIO-100"]}
           animatedRef={animatedScrollViewRef as any}
           title={"Questo è un titolo lungo, ma lungo lungo davvero, eh!"}
           goBack={() => navigation.goBack()}
@@ -73,7 +71,7 @@ export const HeaderSecondLevelScreenDiscreteTransitionCustomBg = () => {
     >
       <View
         style={{
-          backgroundColor: IOColors["blueIO-600"],
+          backgroundColor: IOColors["blueIO-100"],
           height: 800,
           position: "absolute",
           top: -400,

--- a/src/components/buttons/IconButton.tsx
+++ b/src/components/buttons/IconButton.tsx
@@ -9,6 +9,7 @@ import {
   IOColors,
   IOIconButtonStyles,
   IOStyles,
+  IOThemeLight,
   hexToRgba,
   useIOExperimentalDesign,
   useIOTheme
@@ -30,6 +31,7 @@ export type IconButton = WithTestID<{
   accessibilityLabel: string;
   accessibilityHint?: string;
   onPress: (event: GestureResponderEvent) => void;
+  persistentColorMode?: boolean;
 }>;
 
 type ColorStates = {
@@ -76,6 +78,7 @@ const AnimatedIconClassComponent =
 
 export const IconButton = ({
   color = "primary",
+  persistentColorMode = false,
   icon,
   iconSize = 24,
   disabled = false,
@@ -106,9 +109,15 @@ export const IconButton = ({
       // Neutral button
       neutral: {
         icon: {
-          default: IOColors[theme["neutralButton-default"]],
-          pressed: IOColors[theme["neutralButton-pressed"]],
-          disabled: IOColors[theme["neutralButton-disabled"]]
+          default: persistentColorMode
+            ? IOColors[IOThemeLight["neutralButton-default"]]
+            : IOColors[theme["neutralButton-default"]],
+          pressed: persistentColorMode
+            ? IOColors[IOThemeLight["neutralButton-pressed"]]
+            : IOColors[theme["neutralButton-pressed"]],
+          disabled: persistentColorMode
+            ? IOColors[IOThemeLight["neutralButton-disabled"]]
+            : IOColors[theme["neutralButton-disabled"]]
         }
       },
       // Contrast button
@@ -120,7 +129,7 @@ export const IconButton = ({
         }
       }
     }),
-    [theme]
+    [persistentColorMode, theme]
   );
 
   const colorMap = useMemo(

--- a/src/core/IOColors.ts
+++ b/src/core/IOColors.ts
@@ -346,7 +346,7 @@ export const IOThemeDark: IOTheme = {
   "buttonText-disabled": "grey-300",
   "listItem-pressed": "grey-850",
   // Typography
-  "textHeading-default": "grey-200",
+  "textHeading-default": "white",
   "textHeading-secondary": "grey-300",
   "textHeading-tertiary": "grey-450",
   "textBody-default": "white",


### PR DESCRIPTION
## Short description
This PR fixes an issue that occurred when a certain variant was set to `HeaderSecondLevel` and dark mode was enabled.

### The problem
After the recent introduction of dark mode support for `IconButton`, all icon buttons rendered with dark tones were automatically switched to light tones when dark mode was enabled. This behavior is welcome in most cases, but we have some specific app screens where we set a specific variant (e.g., always light or always dark) regarding the enabled color scheme. 

This is especially common when we set a custom background color. In these cases, if you explicitly set the `HeaderSecondLevel` to dark tones (`neutral` variant), the color was automatically switched to light tones when dark mode was enabled.

> [!note]
> The fix only applies to the new UI. Don't expect the fix to work on the legacy UI

## List of changes proposed in this pull request
- Add a new `persistentColorMode` prop to the `IconButton`. This prevents the color from switching automatically
- Refactor the inner logic of `HeaderSecondLevel` by applying `persistentColorMode` only when variant is set
- **[extra]** Add support for `FlatList` to the `animatedRef` prop

### Preview

https://github.com/user-attachments/assets/ba20d1d3-d96e-4682-9842-b165abe4558a


## How to test
Edit the props of the different `HeaderSecondLevel` screens included in the example app and test them in both light and dark mode