### PR TITLE
refactor: [IOBP-1163] Apply ignore accessibility flag

### DIFF
--- a/src/components/layout/HeaderSecondLevel.tsx
+++ b/src/components/layout/HeaderSecondLevel.tsx
@@ -78,6 +78,9 @@ type CommonProps = WithTestID<{
   variant?: "neutral" | "contrast";
   backgroundColor?: string;
   ignoreSafeAreaMargin?: boolean;
+  // Prevents screen readers from focusing on the title when other elements are focused
+  // (e.g. when an input text is throwing an error)
+  ignoreAccessibilityCheck?: boolean;
 }>;
 
 interface Base extends CommonProps {
@@ -151,7 +154,8 @@ export const HeaderSecondLevel = ({
   testID,
   firstAction,
   secondAction,
-  thirdAction
+  thirdAction,
+  ignoreAccessibilityCheck = false
 }: HeaderSecondLevel) => {
   const scrollOffset = useScrollViewOffset(
     (animatedRef as AnimatedRef<Animated.ScrollView>) ||
@@ -299,7 +303,9 @@ export const HeaderSecondLevel = ({
           ref={titleRef}
           accessibilityElementsHidden={!isTitleAccessible}
           importantForAccessibility={
-            isTitleAccessible ? "yes" : "no-hide-descendants"
+            isTitleAccessible && !ignoreAccessibilityCheck
+              ? "yes"
+              : "no-hide-descendants"
           }
           accessible={isTitleAccessible}
           accessibilityLabel={title}


### PR DESCRIPTION
## Short description
This pull request introduces an enhancement to the `HeaderSecondLevel` component to improve accessibility handling. The main change is the addition of an `ignoreAccessibilityCheck` prop, which allows screen readers to bypass focusing on the title when other elements are focused, such as when an input text field is throwing an error.

## List of changes proposed in this pull request
- Added `ignoreAccessibilityCheck` prop to `CommonProps` to control whether the title should be ignored by screen readers when other elements are focused.
## How to test
N/A

## Preview
That's an example of what this change is resolving (look at the screen reader):

https://github.com/user-attachments/assets/b9642dca-cc66-4b15-8555-8d294cdde862

