### PR TITLE
ci: Update storybook `upload-pages-artifact@v3`

### DIFF
--- a/.github/workflows/release-storybook.yml
+++ b/.github/workflows/release-storybook.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build Storybook
         run: yarn predeploy
       - name: 'upload'
-        uses: pload-pages-artifact@v3.0.1 #v3.0.1
+        uses: actions/upload-pages-artifact@v3.0.1 #v3.0.1
         with: 
           path: "storybook-static"
       - id: deploy

--- a/.github/workflows/release-storybook.yml
+++ b/.github/workflows/release-storybook.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build Storybook
         run: yarn predeploy
       - name: 'upload'
-        uses: actions/upload-pages-artifact@v3.0.1 #v3.0.1
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa #v3.0.1
         with: 
           path: "storybook-static"
       - id: deploy

--- a/.github/workflows/release-storybook.yml
+++ b/.github/workflows/release-storybook.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build Storybook
         run: yarn predeploy
       - name: 'upload'
-        uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c #v2.0.0
+        uses: pload-pages-artifact@v3.0.1 #v3.0.1
         with: 
           path: "storybook-static"
       - id: deploy


### PR DESCRIPTION
## Short description
This pull request update the `upload-pages-artifact` action to `v3.0.1` as it fix the [deprecation of upload-artifact@v3
](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

