### PR TITLE
ci: Update `deploy-pages` to `v4.0.5`

### DIFF
--- a/.github/workflows/release-storybook.yml
+++ b/.github/workflows/release-storybook.yml
@@ -28,7 +28,7 @@ jobs:
           path: "storybook-static"
       - id: deploy
         name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@9dbe3824824f8a1377b8e298bafde1a50ede43e5 #v2.0.4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e #v4.0.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
         


### PR DESCRIPTION
## Short description
This pull request updates the `deploy-pages` action from version (v2.0.4) to (v4.0.5)
