### PR TITLE
[IOPLT-952] Fix `TextInputValidation` regression

### DIFF
--- a/src/components/textInput/TextInputValidation.tsx
+++ b/src/components/textInput/TextInputValidation.tsx
@@ -86,12 +86,12 @@ export const TextInputValidation = ({
   }, [onFocus]);
 
   const labelError = useMemo(
-    () => (!isValid && errMessage ? errMessage : bottomMessage),
+    () => (isValid === false && errMessage ? errMessage : bottomMessage),
     [isValid, errMessage, bottomMessage]
   );
 
   const labelErrorColor: IOColors | undefined = useMemo(
-    () => (!isValid && errMessage ? theme.errorText : undefined),
+    () => (isValid === false && errMessage ? theme.errorText : undefined),
     [isValid, errMessage, theme.errorText]
   );
 


### PR DESCRIPTION
## Short description
This PR fixes a regression of `TextInputValidation` that was erroneously introduced by changing the condition associated with `labelError`.

## List of changes proposed in this pull request
- Restore previous strict condition

## How to test
Previously `TextInputValidation` showed the label error in the initial state because `isValid` was set to `undefined`. Verify that this behavior no longer occurs