### PR TITLE
[IOAPPX-481] Refactor `TabItem` and add support for dark mode

### DIFF
--- a/src/components/tabs/TabItem.tsx
+++ b/src/components/tabs/TabItem.tsx
@@ -18,7 +18,7 @@ import {
 import { useScaleAnimation } from "../../hooks";
 import { WithTestID } from "../../utils/types";
 import { IOIcons, Icon } from "../icons";
-import { BodySmall } from "../typography";
+import { IOText } from "../typography";
 
 type ColorMode = "light" | "dark";
 
@@ -240,9 +240,14 @@ const TabItem = ({
         {activeIcon && (
           <Icon name={activeIcon} color={foregroundColor} size={16} />
         )}
-        <BodySmall weight="Semibold" color={foregroundColor}>
+        <IOText
+          size={14}
+          font={isExperimental ? "Titillio" : "TitilliumSansPro"}
+          weight="Semibold"
+          color={foregroundColor}
+        >
           {label}
-        </BodySmall>
+        </IOText>
       </Animated.View>
     </Pressable>
   );

--- a/src/components/tabs/TabItem.tsx
+++ b/src/components/tabs/TabItem.tsx
@@ -22,6 +22,8 @@ import { BodySmall } from "../typography";
 
 type ColorMode = "light" | "dark";
 
+type TabItemState = "default" | "selected" | "disabled";
+
 export type TabItem = WithTestID<{
   label: string;
   color?: ColorMode;
@@ -168,7 +170,7 @@ const TabItem = ({
     [isExperimental, mapColorStates, color]
   );
 
-  const itemState: "selected" | "disabled" | "default" = selected
+  const itemState: TabItemState = selected
     ? "selected"
     : disabled
     ? "disabled"

--- a/src/components/tabs/TabItem.tsx
+++ b/src/components/tabs/TabItem.tsx
@@ -1,19 +1,19 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import { GestureResponderEvent, Pressable, StyleSheet } from "react-native";
+import ReactNativeHapticFeedback from "react-native-haptic-feedback";
 import Animated, {
-  SharedValue,
   interpolateColor,
   useAnimatedStyle,
   useDerivedValue,
   useReducedMotion,
-  useSharedValue,
   withSpring
 } from "react-native-reanimated";
 import {
   IOColors,
   IOSpringValues,
   hexToRgba,
-  useIOExperimentalDesign
+  useIOExperimentalDesign,
+  useIOTheme
 } from "../../core";
 import { useScaleAnimation } from "../../hooks";
 import { WithTestID } from "../../utils/types";
@@ -42,12 +42,10 @@ type ColorStates = {
   border: {
     default: string;
     selected: string;
-    disabled: string;
   };
   background: {
     default: string;
     selected: string;
-    pressed: string;
   };
   foreground: {
     default: IOColors;
@@ -56,42 +54,7 @@ type ColorStates = {
   };
 };
 
-const mapColorStates: Record<NonNullable<TabItem["color"]>, ColorStates> = {
-  light: {
-    border: {
-      default: IOColors["grey-300"],
-      selected: IOColors["blueIO-500"],
-      disabled: IOColors["grey-300"]
-    },
-    background: {
-      default: IOColors.white,
-      selected: IOColors["blueIO-50"],
-      pressed: IOColors.white
-    },
-    foreground: {
-      default: "black",
-      selected: "blueIO-500",
-      disabled: "grey-700"
-    }
-  },
-  dark: {
-    border: {
-      default: hexToRgba(IOColors.white, 0),
-      selected: IOColors.white,
-      disabled: hexToRgba(IOColors.white, 0.5)
-    },
-    background: {
-      default: hexToRgba(IOColors.white, 0),
-      selected: IOColors.white,
-      pressed: IOColors.white
-    },
-    foreground: {
-      default: "white",
-      selected: "black",
-      disabled: "white"
-    }
-  }
-};
+const DISABLED_OPACITY = 0.5;
 
 const mapLegacyColorStates: Record<
   NonNullable<TabItem["color"]>,
@@ -99,14 +62,12 @@ const mapLegacyColorStates: Record<
 > = {
   light: {
     border: {
-      default: IOColors["grey-300"],
-      selected: IOColors["blue-500"],
-      disabled: hexToRgba(IOColors.white)
+      default: IOColors["grey-450"],
+      selected: IOColors["blue-500"]
     },
     background: {
       default: IOColors.white,
-      selected: hexToRgba(IOColors["blue-500"], 0.1),
-      pressed: IOColors.white
+      selected: hexToRgba(IOColors["blue-500"], 0.1)
     },
     foreground: {
       default: "black",
@@ -117,13 +78,11 @@ const mapLegacyColorStates: Record<
   dark: {
     border: {
       default: hexToRgba(IOColors.white, 0),
-      selected: IOColors.white,
-      disabled: hexToRgba(IOColors.white, 0.5)
+      selected: IOColors.white
     },
     background: {
-      default: "#ffffff00",
-      selected: IOColors.white,
-      pressed: IOColors.white
+      default: hexToRgba(IOColors.white, 0.1),
+      selected: IOColors.white
     },
     foreground: {
       default: "white",
@@ -146,76 +105,112 @@ const TabItem = ({
   icon,
   iconSelected
 }: TabItem) => {
-  const { progress, onPressIn, onPressOut, scaleAnimatedStyle } =
-    useScaleAnimation();
+  const { onPressIn, onPressOut, scaleAnimatedStyle } =
+    useScaleAnimation("medium");
+  const theme = useIOTheme();
   const reducedMotion = useReducedMotion();
 
   const { isExperimental } = useIOExperimentalDesign();
+
+  const mapColorStates: Record<
+    NonNullable<TabItem["color"]>,
+    ColorStates
+  > = useMemo(
+    () => ({
+      light: {
+        border: {
+          default: IOColors[theme["tab-item-border-default"]],
+          selected: hexToRgba(
+            IOColors[theme["tab-item-foreground-selected"]],
+            0.5
+          )
+        },
+        background: {
+          default: hexToRgba(
+            IOColors[theme["tab-item-background-selected"]],
+            0
+          ),
+          selected: hexToRgba(
+            IOColors[theme["tab-item-background-selected"]],
+            0.25
+          ),
+          pressed: IOColors[theme["appBackground-primary"]]
+        },
+        foreground: {
+          default: theme["tab-item-foreground-default"],
+          selected: theme["tab-item-foreground-selected"],
+          disabled: "grey-700"
+        }
+      },
+      dark: {
+        border: {
+          default: hexToRgba(IOColors.white, 0),
+          selected: IOColors.white
+        },
+        background: {
+          default: hexToRgba(IOColors.white, 0.1),
+          selected: IOColors.white,
+          pressed: IOColors.white
+        },
+        foreground: {
+          default: "white",
+          selected: "black",
+          disabled: "white"
+        }
+      }
+    }),
+    [theme]
+  );
+
   const colors = useMemo(
     () =>
       isExperimental ? mapColorStates[color] : mapLegacyColorStates[color],
-    [isExperimental, color]
+    [isExperimental, mapColorStates, color]
   );
+
+  const itemState: "selected" | "disabled" | "default" = selected
+    ? "selected"
+    : disabled
+    ? "disabled"
+    : "default";
 
   const foregroundColor = useMemo(
-    () =>
-      colors.foreground[
-        selected ? "selected" : disabled ? "disabled" : "default"
-      ],
-    [colors.foreground, selected, disabled]
+    () => colors.foreground[itemState],
+    [colors.foreground, itemState]
   );
 
-  const borderColor = useMemo(
-    () =>
-      colors.border[selected ? "selected" : disabled ? "disabled" : "default"],
-    [colors.border, selected, disabled]
+  const selectedStateTransition = useDerivedValue(() =>
+    withSpring(selected ? 1 : 0, IOSpringValues.selection)
   );
-
-  const opaquePressedBackgroundColor = hexToRgba(
-    colors.background.pressed,
-    0.1
-  );
-
-  const isSelected: SharedValue<number> = useSharedValue(0);
-  const progressSelected = useDerivedValue(() =>
-    withSpring(isSelected.value, IOSpringValues.selection)
-  );
-
-  useEffect(() => {
-    // eslint-disable-next-line functional/immutable-data
-    isSelected.value = selected ? 1 : 0;
-  }, [isSelected, selected]);
 
   // Interpolate animation values from `pressed` values
-  const animatedStyle = useAnimatedStyle(() => {
-    // Link color states to the pressed states
-    const pressedBackgroundColor = interpolateColor(
-      progress.value,
-      [0, 1],
-      [colors.background.default, opaquePressedBackgroundColor]
-    );
-
-    const selectedBackgroundColor = interpolateColor(
-      progressSelected.value,
-      [0, 1],
-      [opaquePressedBackgroundColor, colors.background.selected]
-    );
-
-    const selectedBorderColor = interpolateColor(
-      progressSelected.value,
-      [0, 1],
-      [colors.border.default, colors.border.selected]
-    );
-
-    return {
-      backgroundColor: selected
-        ? selectedBackgroundColor
-        : pressedBackgroundColor,
-      borderColor: selected ? selectedBorderColor : borderColor
-    };
-  }, [progress, progressSelected, selected]);
+  const animatedStyle = useAnimatedStyle(
+    () => ({
+      backgroundColor: interpolateColor(
+        selectedStateTransition.value,
+        [0, 1],
+        [colors.background.default, colors.background.selected]
+      ),
+      borderColor: interpolateColor(
+        selectedStateTransition.value,
+        [0, 1],
+        [colors.border.default, colors.border.selected]
+      )
+    }),
+    [selectedStateTransition]
+  );
 
   const activeIcon = selected ? iconSelected ?? icon : icon;
+
+  const handleOnPress = useCallback(
+    (event: GestureResponderEvent) => {
+      if (onPress) {
+        ReactNativeHapticFeedback.trigger("impactLight");
+        onPress(event);
+      }
+    },
+    [onPress]
+  );
 
   return (
     <Pressable
@@ -224,7 +219,7 @@ const TabItem = ({
       accessibilityRole={"button"}
       accessibilityState={{ selected }}
       testID={testID}
-      onPress={onPress}
+      onPress={handleOnPress}
       onPressIn={onPressIn}
       onPressOut={onPressOut}
       accessible={true}
@@ -234,10 +229,10 @@ const TabItem = ({
         style={[
           styles.container,
           { columnGap: 4 },
-          !reducedMotion && scaleAnimatedStyle,
+          !disabled && !reducedMotion && scaleAnimatedStyle,
           animatedStyle,
           fullWidth && styles.fullWidth,
-          disabled && styles.disabled
+          disabled && { opacity: DISABLED_OPACITY }
         ]}
       >
         {activeIcon && (
@@ -265,8 +260,7 @@ const styles = StyleSheet.create({
   },
   fullWidth: {
     alignSelf: "auto"
-  },
-  disabled: { opacity: 0.5 }
+  }
 });
 
 export { TabItem };

--- a/src/core/IOColors.ts
+++ b/src/core/IOColors.ts
@@ -40,7 +40,6 @@ export const IOColors = asIOColors({
   "blueIO-600": "#0932B6",
   "blueIO-500": "#0B3EE3",
   "blueIO-400": "#3C65E9",
-  "blueIO-450": "#2351E6" /* Dark mode */,
   "blueIO-200": "#9DB2F4",
   "blueIO-150": "#B6C5F7",
   "blueIO-100": "#CED8F9",
@@ -153,7 +152,6 @@ export const IOColorsTints = asIOColors({
   "blueIO-850": IOColors["blueIO-850"],
   "blueIO-600": IOColors["blueIO-600"],
   "blueIO-500": IOColors["blueIO-500"],
-  "blueIO-450": IOColors["blueIO-450"],
   "blueIO-200": IOColors["blueIO-200"],
   "blueIO-150": IOColors["blueIO-150"],
   "blueIO-100": IOColors["blueIO-100"],
@@ -255,7 +253,6 @@ const themeKeys = [
   "pdfViewer-background",
   // Tab Item
   "tab-item-border-default",
-  "tab-item-border-selected",
   "tab-item-foreground-default",
   "tab-item-foreground-selected",
   "tab-item-background-selected",
@@ -317,7 +314,6 @@ export const IOThemeLight: IOTheme = {
   "pdfViewer-background": "grey-700",
   // Tab Item
   "tab-item-border-default": "grey-300",
-  "tab-item-border-selected": "blueIO-200",
   "tab-item-foreground-default": "black",
   "tab-item-foreground-selected": "blueIO-500",
   "tab-item-background-selected": "blueIO-200",
@@ -348,7 +344,7 @@ export const IOThemeDark: IOTheme = {
   "appBackground-primary": "black",
   "appBackground-secondary": "grey-850",
   "appBackground-tertiary": "grey-700",
-  "interactiveElem-default": "blueIO-450",
+  "interactiveElem-default": "blueIO-400",
   "interactiveElem-pressed": "blueIO-500",
   "interactiveElem-disabled": "grey-700",
   "interactiveOutline-disabled": "grey-450",
@@ -376,10 +372,9 @@ export const IOThemeDark: IOTheme = {
   "textInputValue-disabled": "grey-100",
   // Tab Item
   "tab-item-border-default": "grey-700",
-  "tab-item-border-selected": "grey-700",
   "tab-item-foreground-default": "grey-200",
   "tab-item-foreground-selected": "blueIO-200",
-  "tab-item-background-selected": "blueIO-450",
+  "tab-item-background-selected": "blueIO-400",
   // Layout
   "divider-header": "grey-850",
   "divider-default": "grey-850",

--- a/src/core/IOColors.ts
+++ b/src/core/IOColors.ts
@@ -253,6 +253,13 @@ const themeKeys = [
   "divider-default",
   "divider-bottomBar",
   "pdfViewer-background",
+  // Tab Item
+  "tab-item-border-default",
+  "tab-item-border-selected",
+  "tab-item-foreground-default",
+  "tab-item-foreground-selected",
+  "tab-item-background-selected",
+
   // Status
   "errorIcon",
   "errorText",
@@ -308,6 +315,12 @@ export const IOThemeLight: IOTheme = {
   "divider-default": "grey-200",
   "divider-bottomBar": "grey-200",
   "pdfViewer-background": "grey-700",
+  // Tab Item
+  "tab-item-border-default": "grey-300",
+  "tab-item-border-selected": "blueIO-200",
+  "tab-item-foreground-default": "black",
+  "tab-item-foreground-selected": "blueIO-500",
+  "tab-item-background-selected": "blueIO-200",
   // Status
   errorIcon: "error-600",
   errorText: "error-600",
@@ -361,6 +374,12 @@ export const IOThemeDark: IOTheme = {
   "textInputLabel-default": "grey-450",
   "textInputValue-default": "white",
   "textInputValue-disabled": "grey-100",
+  // Tab Item
+  "tab-item-border-default": "grey-700",
+  "tab-item-border-selected": "grey-700",
+  "tab-item-foreground-default": "grey-200",
+  "tab-item-foreground-selected": "blueIO-200",
+  "tab-item-background-selected": "blueIO-450",
   // Layout
   "divider-header": "grey-850",
   "divider-default": "grey-850",


### PR DESCRIPTION
## Short description
This PR refactors `TabItem` and add support for dark mode

## List of changes proposed in this pull request
- Simplify the internal logic by showing the _pill_ shape in the light variant even in the _default_ state
  - Compared to the previous one, the component only scales when pressed and doesn't change the background color
- Add dark mode support for the component
- Replace `BodySmall` with `IOText` to fix Android wrong alignment
- Remove the unused `blueIO-450` tint
- Add a slight haptic feedback when pressed

### Preview

https://github.com/user-attachments/assets/76867274-d81b-4391-a02f-3a80438db5ce



## How to test
Launch the example app and go to the **Tab Navigation** screen. Test and play with the components placed there.