### PR TITLE
ci: [IOAPPX-483] Update `actions/cache` due to GitHb deprecation

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,7 +11,7 @@ runs:
 
     - name: Cache dependencies
       id: yarn-cache
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: |
           **/node_modules


### PR DESCRIPTION
## Short description
This PR updates `actions/cache` to fix the errors in the PR workflow.