### PR TITLE
refactor(Banner): `a11y` replace `View` with `Pressable`

### DIFF
--- a/src/components/banner/Banner.tsx
+++ b/src/components/banner/Banner.tsx
@@ -206,13 +206,14 @@ export const Banner = ({
         {action && (
           /* Disable pointer events to avoid
              pressed state on the button */
-          <View
+          <Pressable
             pointerEvents="none"
             importantForAccessibility="no-hide-descendants"
             accessible={true}
             accessibilityElementsHidden
             accessibilityLabel={action}
             accessibilityRole="button"
+            onPress={onPress}
           >
             <VSpacer size={4} />
             <IOText
@@ -229,7 +230,7 @@ export const Banner = ({
             >
               {action}
             </IOText>
-          </View>
+          </Pressable>
         )}
       </View>
       <View style={[styles.bleedPictogram, IOStyles.selfCenter]}>

--- a/src/components/banner/__test__/__snapshots__/banner.test.tsx.snap
+++ b/src/components/banner/__test__/__snapshots__/banner.test.tsx.snap
@@ -103,8 +103,36 @@ exports[`Test Banner Components - Experimental Enabled Banner Snapshot 1`] = `
         accessibilityElementsHidden={true}
         accessibilityLabel="Action text"
         accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
         accessible={true}
+        collapsable={false}
+        focusable={true}
         importantForAccessibility="no-hide-descendants"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         pointerEvents="none"
       >
         <View
@@ -380,8 +408,36 @@ exports[`Test Banner Components Banner Snapshot 1`] = `
         accessibilityElementsHidden={true}
         accessibilityLabel="Action text"
         accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
         accessible={true}
+        collapsable={false}
+        focusable={true}
         importantForAccessibility="no-hide-descendants"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         pointerEvents="none"
       >
         <View


### PR DESCRIPTION
## Short description
This pull request includes changes to improve the accessibility and functionality of the `Banner` component. 

## List of changes proposed in this pull request
- Replacing the `View` component with a `Pressable` component for better handling of user interactions.
- Feature B

## How to test
- Using a real device 📱, go in a `Banner` section
- Turn on the TalkBack accessibility tool
- Ensure that action buttons are pressable and reachable using only the keyboard

## Preview
| Old (unable to trigger with `Enter`) | New|
|--------|--------|
| <video src="https://github.com/user-attachments/assets/0bf69143-1203-450d-be03-89dcc35c83fc"/> | <video src="https://github.com/user-attachments/assets/936d55b0-1854-4996-bcea-d9b75dce7d26"/> |




