### PR TITLE
chore: [IOPLT-973] Improve markdown related typographic styles

### DIFF
--- a/src/components/typography/markdown/MdH1.tsx
+++ b/src/components/typography/markdown/MdH1.tsx
@@ -6,7 +6,6 @@ import { IOText, IOTextProps, TypographicStyleProps } from "../IOText";
 /**
  * `MdH1` typographic style
  */
-
 export const MdH1 = forwardRef<View, TypographicStyleProps>(
   ({ color: customColor, ...props }, ref?: ForwardedRef<View>) => {
     const theme = useIOTheme();
@@ -18,7 +17,7 @@ export const MdH1 = forwardRef<View, TypographicStyleProps>(
       weight: "Semibold",
       size: 20,
       lineHeight: 24,
-      color: customColor ?? theme["textHeading-tertiary"]
+      color: customColor ?? theme["textHeading-default"]
     };
 
     return (

--- a/src/components/typography/markdown/MdH2.tsx
+++ b/src/components/typography/markdown/MdH2.tsx
@@ -15,9 +15,9 @@ export const MdH2 = forwardRef<View, TypographicStyleProps>(
       ...props,
       font: isExperimental ? "Titillio" : "TitilliumSansPro",
       weight: "Semibold",
-      size: 16,
+      size: 18,
       lineHeight: 24,
-      color: customColor ?? theme["textHeading-tertiary"]
+      color: customColor ?? theme["textHeading-default"]
     };
 
     return (

--- a/src/components/typography/markdown/MdH3.tsx
+++ b/src/components/typography/markdown/MdH3.tsx
@@ -14,7 +14,7 @@ export const MdH3 = forwardRef<View, TypographicStyleProps>(
     const MdH3Props: IOTextProps = {
       ...props,
       font: isExperimental ? "Titillio" : "TitilliumSansPro",
-      weight: "Regular",
+      weight: "Semibold",
       size: 16,
       lineHeight: 24,
       color: customColor ?? theme["textHeading-default"]

--- a/src/components/typography/markdown/MdH3.tsx
+++ b/src/components/typography/markdown/MdH3.tsx
@@ -17,7 +17,7 @@ export const MdH3 = forwardRef<View, TypographicStyleProps>(
       weight: "Regular",
       size: 16,
       lineHeight: 24,
-      color: customColor ?? theme["textHeading-tertiary"]
+      color: customColor ?? theme["textHeading-default"]
     };
 
     return (

--- a/src/core/IOColors.ts
+++ b/src/core/IOColors.ts
@@ -381,7 +381,7 @@ export const IOThemeDark: IOTheme = {
   "textHeading-tertiary": "grey-450",
   "textBody-default": "white",
   "textBody-secondary": "grey-100",
-  "textBody-tertiary": "grey-450",
+  "textBody-tertiary": "grey-300",
   // Design System related
   "cardBorder-default": "grey-850",
   "icon-default": "grey-450",


### PR DESCRIPTION
## Short description
This PR improves the markdown related typographic styles and some styles associated to dark mode.

## List of changes proposed in this pull request
- Increase the `MdH2` size 
- Change weight of `MdH3` typographic style
- Increase contrast of `textBody-tertiary` in dark mode
- Make the fallback color darker than the current color

## How to test
1. Launch the example app
2. Look at the end of the **Typography** screen