### PR TITLE
feat: support for `onBlur` and `onContinue` validation modes in `TextInputValidation` component

### DIFF
--- a/example/src/pages/TextInputs.tsx
+++ b/example/src/pages/TextInputs.tsx
@@ -1,5 +1,4 @@
 import {
-  ButtonSolid,
   H4,
   H5,
   IOStyles,
@@ -10,7 +9,7 @@ import {
   VSpacer
 } from "@pagopa/io-app-design-system";
 import * as React from "react";
-import { Button, TextInputBase, View } from "react-native";
+import { Button, View } from "react-native";
 import { Screen } from "../components/Screen";
 
 const InputComponentWrapper = (

--- a/example/src/pages/TextInputs.tsx
+++ b/example/src/pages/TextInputs.tsx
@@ -1,4 +1,5 @@
 import {
+  ButtonSolid,
   H4,
   H5,
   IOStyles,
@@ -9,7 +10,7 @@ import {
   VSpacer
 } from "@pagopa/io-app-design-system";
 import * as React from "react";
-import { View } from "react-native";
+import { Button, TextInputBase, View } from "react-native";
 import { Screen } from "../components/Screen";
 
 const InputComponentWrapper = (
@@ -70,6 +71,36 @@ const InputPasswordComponentWrapper = (
     </>
   );
 };
+
+const TextInputValidationOnContinue = (
+  props: Omit<
+    React.ComponentProps<typeof TextInputValidation>,
+    "value" | "onChangeText"
+  > & { value?: string }
+) => {
+  const textInputRef = React.useRef<{ validateInput: () => void }>(null);
+
+  const handleContinue = () => {
+    textInputRef.current?.validateInput();
+  };
+  const [inputValue, setInputValue] = React.useState(props.value ?? "");
+
+  return (
+    <>
+      <VSpacer />
+      <TextInputValidation
+        {...props}
+        ref={textInputRef}
+        value={inputValue}
+        onChangeText={setInputValue}
+        validationMode="onContinue"
+      />
+      <Button title="Continue" onPress={handleContinue} />
+      <VSpacer />
+    </>
+  );
+};
+
 /**
  * This Screen is used to test components in isolation while developing.
  * @returns a screen with a flexed view where you can test components
@@ -100,8 +131,20 @@ export const TextInputs = () => (
         bottomMessage="Inserisci almeno 3 caratteri"
         errorMessage="Inserisci almeno 3 caratteri"
       />
+      <TextInputValidationOnContinue
+        placeholder={"Base input"}
+        onValidate={value => value.length > 2}
+        bottomMessage="Inserisci almeno 3 caratteri"
+        errorMessage="Inserisci almeno 3 caratteri"
+      />
       <H5>Base input with validation and error</H5>
       <InputValidationComponentWrapper
+        placeholder={"Base input"}
+        onValidate={value => value.length > 2}
+        bottomMessage="Inserisci almeno 3 caratteri"
+        errorMessage="Troppo corto"
+      />
+      <TextInputValidationOnContinue
         placeholder={"Base input"}
         onValidate={value => value.length > 2}
         bottomMessage="Inserisci almeno 3 caratteri"

--- a/src/components/textInput/TextInputValidation.tsx
+++ b/src/components/textInput/TextInputValidation.tsx
@@ -1,5 +1,11 @@
 import * as React from "react";
-import { useCallback, useMemo, useState } from "react";
+import {
+  useCallback,
+  useMemo,
+  useState,
+  forwardRef,
+  useImperativeHandle
+} from "react";
 import { AccessibilityInfo, View } from "react-native";
 import Animated from "react-native-reanimated";
 import { useIOTheme } from "../../core";
@@ -28,6 +34,10 @@ type TextInputValidationProps = Omit<
    * In case of a dynamic `errorMessage`, use the `onValidate` function with a `ValidationWithOptions` object as the return value to ensure that screen readers announce the correct value.
    */
   errorMessage: string;
+  /**
+   * Determines the validation mode. If "onBlur", validation occurs on blur. If "onContinue", validation occurs when an external button is pressed.
+   */
+  validationMode?: "onBlur" | "onContinue";
 };
 
 function isValidationWithOptions(
@@ -42,107 +52,132 @@ function isValidationWithOptions(
 
 const feedbackIconSize: IOIconSizeScale = 24;
 
-export const TextInputValidation = ({
-  onValidate,
-  errorMessage,
-  value,
-  bottomMessage,
-  onBlur,
-  onFocus,
-  ...props
-}: TextInputValidationProps) => {
-  const theme = useIOTheme();
-  const [isValid, setIsValid] = useState<boolean | undefined>(undefined);
-  const [errMessage, setErrMessage] = useState(errorMessage);
+export const TextInputValidation = forwardRef<
+  {
+    validateInput: () => void;
+  },
+  TextInputValidationProps
+>(
+  (
+    {
+      onValidate,
+      errorMessage,
+      value,
+      bottomMessage,
+      onBlur,
+      onFocus,
+      validationMode = "onBlur",
+      ...props
+    },
+    ref
+  ) => {
+    const theme = useIOTheme();
+    const [isValid, setIsValid] = useState<boolean | undefined>(undefined);
+    const [errMessage, setErrMessage] = useState(errorMessage);
 
-  const getErrorFeedback = useCallback((isValid: boolean, message: string) => {
-    setIsValid(isValid);
-    setErrMessage(message);
+    const getErrorFeedback = useCallback(
+      (isValid: boolean, message: string) => {
+        setIsValid(isValid);
+        setErrMessage(message);
 
-    if (!isValid) {
-      triggerHaptic("notificationError");
-      AccessibilityInfo.announceForAccessibilityWithOptions(message, {
-        queue: true
-      });
-    } else {
-      triggerHaptic("notificationSuccess");
-    }
-  }, []);
-
-  const onBlurHandler = useCallback(() => {
-    const validation = onValidate(value);
-
-    if (isValidationWithOptions(validation)) {
-      getErrorFeedback(validation.isValid, validation.errorMessage);
-    } else {
-      getErrorFeedback(validation, errorMessage);
-    }
-    onBlur?.();
-  }, [value, errorMessage, onBlur, onValidate, getErrorFeedback]);
-
-  const onFocusHandler = useCallback(() => {
-    setIsValid(undefined);
-    onFocus?.();
-  }, [onFocus]);
-
-  const labelError = useMemo(
-    () => (isValid === false && errMessage ? errMessage : bottomMessage),
-    [isValid, errMessage, bottomMessage]
-  );
-
-  const labelErrorColor: IOColors | undefined = useMemo(
-    () => (isValid === false && errMessage ? theme.errorText : undefined),
-    [isValid, errMessage, theme.errorText]
-  );
-
-  const feedbackIconAttrMap: Record<
-    string,
-    { name: IOIcons; color: IOColors }
-  > = useMemo(
-    () => ({
-      valid: {
-        name: "success",
-        color: theme.successIcon
+        if (!isValid) {
+          triggerHaptic("notificationError");
+          AccessibilityInfo.announceForAccessibilityWithOptions(message, {
+            queue: true
+          });
+        } else {
+          triggerHaptic("notificationSuccess");
+        }
       },
-      notValid: {
-        name: "errorFilled",
-        color: theme.errorIcon
-      }
-    }),
-    [theme]
-  );
-
-  const feedbackIcon = useMemo(() => {
-    const validationStatus = isValid ? "valid" : "notValid";
-
-    return isValid !== undefined ? (
-      <Animated.View
-        entering={enterTransitionInputIcon}
-        exiting={exitTransitionInputIcon}
-      >
-        <Icon
-          name={feedbackIconAttrMap[validationStatus].name}
-          color={feedbackIconAttrMap[validationStatus].color}
-          size={feedbackIconSize}
-        />
-      </Animated.View>
-    ) : (
-      <View style={{ width: feedbackIconSize, height: feedbackIconSize }} />
+      []
     );
-  }, [feedbackIconAttrMap, isValid]);
 
-  return (
-    <TextInputBase
-      {...props}
-      value={value}
-      status={isValid === false ? "error" : undefined}
-      bottomMessage={labelError}
-      bottomMessageColor={labelErrorColor}
-      rightElement={feedbackIcon}
-      onBlur={onBlurHandler}
-      onFocus={onFocusHandler}
-    />
-  );
-};
+    const validateInput = useCallback(() => {
+      const validation = onValidate(value);
+
+      if (isValidationWithOptions(validation)) {
+        getErrorFeedback(validation.isValid, validation.errorMessage);
+      } else {
+        getErrorFeedback(validation, errorMessage);
+      }
+    }, [value, errorMessage, onValidate, getErrorFeedback]);
+
+    // Expose the validateInput function to the parent component
+    useImperativeHandle(ref, () => ({
+      validateInput
+    }));
+
+    const onBlurHandler = useCallback(() => {
+      if (validationMode === "onBlur") {
+        validateInput();
+      }
+      onBlur?.();
+    }, [validationMode, validateInput, onBlur]);
+
+    const onFocusHandler = useCallback(() => {
+      setIsValid(undefined);
+      onFocus?.();
+    }, [onFocus]);
+
+    const labelError = useMemo(
+      () => (isValid === false && errMessage ? errMessage : bottomMessage),
+      [isValid, errMessage, bottomMessage]
+    );
+
+    const labelErrorColor: IOColors | undefined = useMemo(
+      () => (isValid === false && errMessage ? theme.errorText : undefined),
+      [isValid, errMessage, theme.errorText]
+    );
+
+    const feedbackIconAttrMap: Record<
+      string,
+      { name: IOIcons; color: IOColors }
+    > = useMemo(
+      () => ({
+        valid: {
+          name: "success",
+          color: theme.successIcon
+        },
+        notValid: {
+          name: "errorFilled",
+          color: theme.errorIcon
+        }
+      }),
+      [theme]
+    );
+
+    const feedbackIcon = useMemo(() => {
+      const validationStatus = isValid ? "valid" : "notValid";
+
+      return isValid !== undefined ? (
+        <Animated.View
+          entering={enterTransitionInputIcon}
+          exiting={exitTransitionInputIcon}
+        >
+          <Icon
+            name={feedbackIconAttrMap[validationStatus].name}
+            color={feedbackIconAttrMap[validationStatus].color}
+            size={feedbackIconSize}
+          />
+        </Animated.View>
+      ) : (
+        <View style={{ width: feedbackIconSize, height: feedbackIconSize }} />
+      );
+    }, [feedbackIconAttrMap, isValid]);
+
+    return (
+      <TextInputBase
+        {...props}
+        value={value}
+        status={isValid === false ? "error" : undefined}
+        bottomMessage={labelError}
+        bottomMessageColor={labelErrorColor}
+        rightElement={feedbackIcon}
+        onBlur={onBlurHandler}
+        onFocus={onFocusHandler}
+      />
+    );
+  }
+);
 
 export default TextInputValidation;

--- a/src/components/textInput/TextInputValidation.tsx
+++ b/src/components/textInput/TextInputValidation.tsx
@@ -97,7 +97,7 @@ export const TextInputValidation = forwardRef<
           triggerHaptic("notificationSuccess");
         }
       },
-      []
+      [accessibilityErrorLabel]
     );
 
     const validateInput = useCallback(() => {


### PR DESCRIPTION
## Short description
This pull request introduces a new validation mode for the `TextInputValidation` component, enabling validation based on a trigger event

## List of changes proposed in this pull request
- Added a new `validationMode` prop to determine whether validation occurs on blur or when an external button is pressed. Refactored the component to use `forwardRef` and `useImperativeHandle` to expose the `validateInput` function to parent components
- Added a new `TextInputValidationOnContinue` component that uses the new `validationMode` prop to validate input when a "Continue" button is pressed. Updated the `TextInputs` page to include instances of this new component. 

## How to test
- Go in `TextInputs`
- Review, test, and verify the functionality of the new `TextInputValidation` implementation.

## Preview
https://github.com/user-attachments/assets/d905c8c6-16c5-415a-9c22-ff11e8cbbf90

