### PR TITLE
fix: [IOPLT-982] Export `a11y` related hooks

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,4 +3,5 @@ export * from "./core";
 export * from "./functions";
 export * from "./hooks";
 export * from "./utils/fonts";
+export * from "./utils/accessibility";
 export * from "./utils/types";


### PR DESCRIPTION
## Short description
This PR exports `a11y` related hooks

## List of changes proposed in this pull request
- Export `useIOFontDynamicScale` and `useBoldTextEnabled` hooks

## How to test
N/A