### PR TITLE
fix: Import `TextInputValidationRefProps` with relative path

### DIFF
--- a/src/components/textInput/TextInputValidation.tsx
+++ b/src/components/textInput/TextInputValidation.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import { AccessibilityInfo, View } from "react-native";
 import Animated from "react-native-reanimated";
-import { TextInputValidationRefProps } from "src/utils/types";
+import { TextInputValidationRefProps } from "../../utils/types";
 import { useIOTheme } from "../../core";
 import { IOColors } from "../../core/IOColors";
 import {


### PR DESCRIPTION
## Short description
This PR fixes an import introduced in the following PR: https://github.com/pagopa/io-app-design-system/pull/410 importing the`TextInputValidationRefProps` type with a relative path.
