### PR TITLE
refactor(Tab): Add prop to exclude padding in container

### DIFF
--- a/src/components/tabs/TabNavigation.tsx
+++ b/src/components/tabs/TabNavigation.tsx
@@ -40,7 +40,7 @@ const TabNavigation = ({
   tabAlignment = "center",
   onItemPress,
   children,
-  includeContentMargins = false
+  includeContentMargins = true
 }: TabNavigation) => {
   const [itemMinWidth, setItemMinWidth] = React.useState<number>(0);
 

--- a/src/components/tabs/TabNavigation.tsx
+++ b/src/components/tabs/TabNavigation.tsx
@@ -23,6 +23,7 @@ type TabNavigation = {
   onItemPress?: (index: number) => void;
   // Tabs
   children: TabNavigationChildren;
+  excludePadding?: boolean;
 };
 
 const itemsJustify: Record<TabAlignment, FlexStyle["justifyContent"]> = {
@@ -37,7 +38,8 @@ const TabNavigation = ({
   selectedIndex,
   tabAlignment = "center",
   onItemPress,
-  children
+  children,
+  excludePadding = false
 }: TabNavigation) => {
   const [itemMinWidth, setItemMinWidth] = React.useState<number>(0);
 
@@ -79,7 +81,7 @@ const TabNavigation = ({
       centerContent={true}
       showsHorizontalScrollIndicator={false}
       contentContainerStyle={[
-        styles.container,
+        excludePadding ? styles.containerNoPadding : styles.container,
         {
           justifyContent: itemsJustify[tabAlignment]
         }
@@ -94,6 +96,9 @@ const styles = StyleSheet.create({
   container: {
     flexGrow: 1,
     paddingHorizontal: 24
+  },
+  containerNoPadding: {
+    flexGrow: 1
   },
   item: {
     flexGrow: 0,

--- a/src/components/tabs/TabNavigation.tsx
+++ b/src/components/tabs/TabNavigation.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FlexStyle, LayoutChangeEvent, StyleSheet, View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
+import { IOVisualCostants } from "src/core";
 import { TabItem } from "./TabItem";
 
 export type TabNavigationItem = Omit<
@@ -23,7 +24,7 @@ type TabNavigation = {
   onItemPress?: (index: number) => void;
   // Tabs
   children: TabNavigationChildren;
-  excludePadding?: boolean;
+  includeContentMargins?: boolean;
 };
 
 const itemsJustify: Record<TabAlignment, FlexStyle["justifyContent"]> = {
@@ -39,7 +40,7 @@ const TabNavigation = ({
   tabAlignment = "center",
   onItemPress,
   children,
-  excludePadding = false
+  includeContentMargins = false
 }: TabNavigation) => {
   const [itemMinWidth, setItemMinWidth] = React.useState<number>(0);
 
@@ -81,8 +82,11 @@ const TabNavigation = ({
       centerContent={true}
       showsHorizontalScrollIndicator={false}
       contentContainerStyle={[
-        excludePadding ? styles.containerNoPadding : styles.container,
+        includeContentMargins
+          ? { paddingHorizontal: IOVisualCostants.appMarginDefault }
+          : {},
         {
+          flexGrow: 1,
           justifyContent: itemsJustify[tabAlignment]
         }
       ]}
@@ -93,13 +97,6 @@ const TabNavigation = ({
 };
 
 const styles = StyleSheet.create({
-  container: {
-    flexGrow: 1,
-    paddingHorizontal: 24
-  },
-  containerNoPadding: {
-    flexGrow: 1
-  },
   item: {
     flexGrow: 0,
     flexShrink: 1,

--- a/src/components/tabs/TabNavigation.tsx
+++ b/src/components/tabs/TabNavigation.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { FlexStyle, LayoutChangeEvent, StyleSheet, View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
-import { IOVisualCostants } from "src/core";
+import { IOVisualCostants } from "../../core";
 import { TabItem } from "./TabItem";
 
 export type TabNavigationItem = Omit<


### PR DESCRIPTION
This props is useful for the new IOScrollViewLargeHeaderWithList component

## Short description
This pull request introduces changes to the `TabNavigation` to add an optional `excludePadding` prop. This prop allows the user to control whether padding is applied to the container

## List of changes proposed in this pull request
- Added an optional `excludePadding` property to the `TabNavigation` type.
- Updated the `contentContainerStyle` to conditionally apply padding based on the `excludePadding` prop.

## How to test
N/A