### PR TITLE
chore: [IOBP-1186] Add `accessibilityLabel` prop to `RadioItem` type component

### DIFF
--- a/src/components/radio/RadioGroup.tsx
+++ b/src/components/radio/RadioGroup.tsx
@@ -5,6 +5,7 @@ import { ListItemRadio, ListItemRadioWithAmount } from "../listitems";
 export type RadioItem<T> = {
   id: T;
   value: string;
+  accessibilityLabel?: string;
   description?: string | React.ReactNode;
   disabled?: boolean;
   startImage?: ComponentProps<typeof ListItemRadio>["startImage"];
@@ -55,6 +56,7 @@ const RadioListItem = <T,>(props: RadioListItemProps<T>) => (
           testID={`RadioItemTestID_${item.id}`}
           value={item.value}
           description={item.description}
+          accessibilityLabel={item.accessibilityLabel}
           startImage={item.startImage}
           disabled={item.disabled}
           loadingProps={item.loadingProps}


### PR DESCRIPTION
## Short description
This PR adds the `accessibilityLabel` prop to the `RadioItem` type to handle a11y in the `RadioGroup` component

## List of changes proposed in this pull request
- Added `accessibilityLabel` prop to the `RadioItem` type
