### PR TITLE
refactor: default hint for a11y label

### DIFF
--- a/src/components/listitems/ListItemRadioWithAmount.tsx
+++ b/src/components/listitems/ListItemRadioWithAmount.tsx
@@ -48,11 +48,15 @@ export const ListItemRadioWithAmount = ({
 
   const suggestColor: IOColors = "hanPurple-500";
 
+  const defaultAccessibilityLabel = `${label} ${formattedAmountString} ${
+    suggestReason ?? ""
+  }`;
+
   return (
     <PressableListItemBase
       onPress={pressHandler}
       accessibilityRole="radio"
-      accessibilityLabel={accessibilityLabel}
+      accessibilityLabel={accessibilityLabel ?? defaultAccessibilityLabel}
       accessibilityState={{
         checked: selected ?? toggleValue
       }}

--- a/src/components/listitems/__test__/__snapshots__/listitem.test.tsx.snap
+++ b/src/components/listitems/__test__/__snapshots__/listitem.test.tsx.snap
@@ -767,6 +767,7 @@ exports[`Test List Item Components - Experimental Enabled  ListItemNavAlert Snap
 
 exports[`Test List Item Components - Experimental Enabled  ListItemRadioWithAmount Snapshot 1`] = `
 <View
+  accessibilityLabel="label € 1.000,00 suggestReason"
   accessibilityRole="radio"
   accessibilityState={
     {
@@ -1140,6 +1141,7 @@ exports[`Test List Item Components - Experimental Enabled  ListItemRadioWithAmou
 
 exports[`Test List Item Components - Experimental Enabled  ListItemRadioWithAmount Snapshot 2`] = `
 <View
+  accessibilityLabel="label € 1.000,00 "
   accessibilityRole="radio"
   accessibilityState={
     {
@@ -2343,6 +2345,7 @@ exports[`Test List Item Components ListItemNavAlert Snapshot 1`] = `
 
 exports[`Test List Item Components ListItemRadioWithAmount Snapshot 1`] = `
 <View
+  accessibilityLabel="label € 1.000,00 suggestReason"
   accessibilityRole="radio"
   accessibilityState={
     {
@@ -2716,6 +2719,7 @@ exports[`Test List Item Components ListItemRadioWithAmount Snapshot 1`] = `
 
 exports[`Test List Item Components ListItemRadioWithAmount Snapshot 2`] = `
 <View
+  accessibilityLabel="label € 1.000,00 "
   accessibilityRole="radio"
   accessibilityState={
     {


### PR DESCRIPTION
## Short description
This pull request includes a change to the `ListItemRadioWithAmount` component to improve its accessibility by providing a default accessibility label 

## List of changes proposed in this pull request
- Added a `defaultAccessibilityLabel` that combines the `label`, `formattedAmountString`, and `suggestReason` if available, and used it as a fallback for `accessibilityLabel` when it's not provide

## How to test
N/A