### PR TITLE
fix: [IOPLT-1028] Add alternative `accessibilityRole` to `Banner`, `FeatureInfo` and all the `asLink` typographic styles

### DIFF
--- a/example/src/pages/Advice.tsx
+++ b/example/src/pages/Advice.tsx
@@ -110,7 +110,8 @@ const renderFeatureInfo = () => {
           }
           action={{
             label: "Scopri di più",
-            onPress: onLinkPress
+            onPress: onLinkPress,
+            accessibilityRole: "button"
           }}
         />
       </ComponentViewerBox>

--- a/example/src/pages/Advice.tsx
+++ b/example/src/pages/Advice.tsx
@@ -137,6 +137,7 @@ const renderBanner = () => (
             pictogramName="charity"
             action="Action text"
             onPress={onLinkPress}
+            accessibilityRole="link"
           />
           <VSpacer size={24} />
           <Banner

--- a/src/components/banner/Banner.tsx
+++ b/src/components/banner/Banner.tsx
@@ -79,9 +79,9 @@ type RequiredBannerProps =
 
 type BannerActionProps =
   | {
-      action?: string;
+      action: string;
       onPress: (event: GestureResponderEvent) => void;
-      accessibilityRole?: never;
+      accessibilityRole?: Extract<AccessibilityRole, "button" | "link">;
     }
   | {
       action?: never;
@@ -142,6 +142,7 @@ export const Banner = ({
   onClose,
   accessibilityHint,
   accessibilityLabel,
+  accessibilityRole = "button",
   testID
 }: Banner) => {
   const { newTypefaceEnabled } = useIONewTypeface();
@@ -178,7 +179,7 @@ export const Banner = ({
         // A11y related props
         accessibilityLabel={accessibilityLabel ?? fallbackAccessibilityLabel}
         accessibilityHint={accessibilityHint}
-        accessibilityRole={action !== undefined ? "button" : undefined}
+        accessibilityRole={action !== undefined ? accessibilityRole : "text"}
       >
         {title && (
           <>
@@ -264,9 +265,6 @@ export const Banner = ({
       style={[styles.container, dynamicContainerStyles]}
       // A11y related props
       accessible={false}
-      accessibilityHint={accessibilityHint}
-      accessibilityLabel={accessibilityLabel}
-      accessibilityRole={"text"}
     >
       {renderMainBlock()}
     </View>

--- a/src/components/featureInfo/FeatureInfo.tsx
+++ b/src/components/featureInfo/FeatureInfo.tsx
@@ -57,6 +57,10 @@ export const FeatureInfo = ({
 }: FeatureInfoProps) => {
   const theme = useIOTheme();
 
+  /* Already defined in the `BodySmall` component as a fallback value,
+  but I keep it here to avoid possible future inconsistencies. */
+  const accessibilityRole = action?.accessibilityRole ?? "link";
+
   return (
     <HStack style={{ alignItems: "center" }} space={24}>
       {iconName && (
@@ -84,7 +88,7 @@ export const FeatureInfo = ({
             accessible
             importantForAccessibility={"yes"}
             accessibilityElementsHidden={false}
-            accessibilityRole={action.accessibilityRole}
+            accessibilityRole={accessibilityRole}
           >
             {action.label}
           </BodySmall>

--- a/src/components/featureInfo/FeatureInfo.tsx
+++ b/src/components/featureInfo/FeatureInfo.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { GestureResponderEvent } from "react-native";
+import { AccessibilityRole, GestureResponderEvent } from "react-native";
 import {
   BodySmall,
   HStack,
@@ -23,6 +23,7 @@ type FeatureInfoActionProps =
       action: {
         label: string;
         onPress: (event: GestureResponderEvent) => void;
+        accessibilityRole?: Extract<AccessibilityRole, "button" | "link">;
       };
     }
   | {
@@ -83,6 +84,7 @@ export const FeatureInfo = ({
             accessible
             importantForAccessibility={"yes"}
             accessibilityElementsHidden={false}
+            accessibilityRole={action.accessibilityRole}
           >
             {action.label}
           </BodySmall>

--- a/src/components/typography/Body.tsx
+++ b/src/components/typography/Body.tsx
@@ -24,7 +24,13 @@ const legacyFontName: IOFontFamily = "TitilliumSansPro";
  */
 export const Body = forwardRef<View, BodyStyleProps>(
   (
-    { weight: customWeight, color: customColor, asLink, ...props },
+    {
+      weight: customWeight,
+      color: customColor,
+      asLink,
+      accessibilityRole = "link",
+      ...props
+    },
     ref?: ForwardedRef<View>
   ) => {
     const theme = useIOTheme();
@@ -44,7 +50,7 @@ export const Body = forwardRef<View, BodyStyleProps>(
       color: customColor ?? defaultColor,
       ...(asLink
         ? {
-            accessibilityRole: "link",
+            accessibilityRole,
             textStyle: { textDecorationLine: "underline" }
           }
         : {})

--- a/src/components/typography/BodySmall.tsx
+++ b/src/components/typography/BodySmall.tsx
@@ -21,7 +21,13 @@ const legacyFontName: IOFontFamily = "TitilliumSansPro";
  */
 export const BodySmall = forwardRef<View, BodySmallProps>(
   (
-    { weight: customWeight, color: customColor, asLink, ...props },
+    {
+      weight: customWeight,
+      color: customColor,
+      asLink,
+      accessibilityRole = "link",
+      ...props
+    },
     ref?: ForwardedRef<View>
   ) => {
     const theme = useIOTheme();
@@ -41,7 +47,7 @@ export const BodySmall = forwardRef<View, BodySmallProps>(
       color: customColor ?? defaultColor,
       ...(asLink
         ? {
-            accessibilityRole: "link",
+            accessibilityRole,
             textStyle: { textDecorationLine: "underline" }
           }
         : {})

--- a/src/components/typography/IOText.tsx
+++ b/src/components/typography/IOText.tsx
@@ -1,5 +1,6 @@
 import React, { ComponentProps, forwardRef, useMemo } from "react";
 import {
+  AccessibilityRole,
   ColorValue,
   GestureResponderEvent,
   Text,
@@ -60,6 +61,7 @@ export type TypographicStyleAsLinkProps =
       color?: never;
       asLink: true;
       onPress: (event: GestureResponderEvent) => void;
+      accessibilityRole?: Extract<AccessibilityRole, "button" | "link">;
     }
   | { color?: IOColors; asLink?: false };
 

--- a/src/components/typography/LabelMini.tsx
+++ b/src/components/typography/LabelMini.tsx
@@ -21,7 +21,13 @@ const legacyFontName: IOFontFamily = "TitilliumSansPro";
  */
 export const LabelMini = forwardRef<View, LabelMiniProps>(
   (
-    { weight: customWeight, color: customColor, asLink, ...props },
+    {
+      weight: customWeight,
+      color: customColor,
+      asLink,
+      accessibilityRole = "link",
+      ...props
+    },
     ref?: ForwardedRef<View>
   ) => {
     const theme = useIOTheme();
@@ -41,7 +47,7 @@ export const LabelMini = forwardRef<View, LabelMiniProps>(
       color: customColor ?? defaultColor,
       ...(asLink
         ? {
-            accessibilityRole: "link",
+            accessibilityRole,
             textStyle: { textDecorationLine: "underline" }
           }
         : {})


### PR DESCRIPTION
## Short description
This PR adds an alternative `accessibilityRole` to `Banner`, `FeatureInfo` and all the typographic styles with the `asLink` prop.

## List of changes proposed in this pull request
- Add possible alternative `button` accessibility role to all the typographic styles with the `asLink` prop
- Add possibile alternative `button` accessibility role to `FeatureInfo`
- Add possibile alternative `link` accessibility role to `Banner`

## How to test
Run the example app and try to edit these components with custom `accessibilityRole`