### PR TITLE
chore: adjust `ModuleCheckout` a11y label

### DIFF
--- a/src/components/modules/ModuleCheckout.tsx
+++ b/src/components/modules/ModuleCheckout.tsx
@@ -84,7 +84,10 @@ export const ModuleCheckout = (props: ModuleCheckoutProps) => {
   );
 
   return ctaText ? (
-    <PressableModuleBase onPress={onPress}>
+    <PressableModuleBase
+      onPress={onPress}
+      accessibilityLabel={`${title} , ${ctaText}`}
+    >
       <HStack space={4} style={{ alignItems: "center" }}>
         <ModuleBaseContent />
         <View

--- a/src/components/modules/ModuleCheckout.tsx
+++ b/src/components/modules/ModuleCheckout.tsx
@@ -86,7 +86,9 @@ export const ModuleCheckout = (props: ModuleCheckoutProps) => {
   return ctaText ? (
     <PressableModuleBase
       onPress={onPress}
-      accessibilityLabel={`${title} , ${ctaText}`}
+      accessibilityLabel={
+        subtitle ? `${title}, ${subtitle}, ${ctaText}` : `${title}, ${ctaText}`
+      }
     >
       <HStack space={4} style={{ alignItems: "center" }}>
         <ModuleBaseContent />


### PR DESCRIPTION
## Short description
This pull request adds an `accessibilityLabel` to the `ModuleCheckout` component to improve screen reader interaction, ensuring that the `CTA` text is announced correctly on Android, which was previously missing.

## List of changes proposed in this pull request
- Add an `accessibilityLabel` to the `PressableModuleBase` component to enhance screen reader support by including the `title` and `ctaText` properties.


## How to test
- Enable TalkBack on Android or VoiceOver on iOS
- Navigate over a `ModuleCheckout` component
- Ensure that both Android and iOS correctly announce the `text` and `cta` if present
