### PR TITLE
chore: [IOPLT-967] Add dark mode support to `OTPInput`

### DIFF
--- a/src/components/otpInput/BoxedInput.tsx
+++ b/src/components/otpInput/BoxedInput.tsx
@@ -36,33 +36,30 @@ const SecretValue = () => (
 export const BoxedInput = ({ status, value, secret }: Props) => {
   const theme = useIOTheme();
 
-  const derivedStyle: ViewStyle = useMemo(() => {
-    switch (status) {
-      case "error":
-        return {
-          borderWidth: 1,
-          borderColor: IOColors[theme["otpInputBorder-error"]],
-          backgroundColor: hexToRgba(
-            IOColors[theme["otpInputBorder-error"]],
-            0.15
-          )
-        };
-      case "focus":
-        return {
-          borderWidth: 2,
-          borderColor: IOColors[theme["interactiveElem-default"]]
-        };
-      case "default":
-      default:
-        return {
-          borderWidth: 1,
-          borderColor: IOColors[theme["otpInputBorder-default"]]
-        };
-    }
-  }, [status, theme]);
+  const statusStyle: Record<Props["status"], ViewStyle> = useMemo(
+    () => ({
+      error: {
+        borderWidth: 1,
+        borderColor: IOColors[theme["otpInputBorder-error"]],
+        backgroundColor: hexToRgba(
+          IOColors[theme["otpInputBorder-error"]],
+          0.15
+        )
+      },
+      focus: {
+        borderWidth: 2,
+        borderColor: IOColors[theme["interactiveElem-default"]]
+      },
+      default: {
+        borderWidth: 1,
+        borderColor: IOColors[theme["otpInputBorder-default"]]
+      }
+    }),
+    [theme]
+  );
 
   return (
-    <View style={[styles.baseBox, derivedStyle]} accessible={false}>
+    <View style={[styles.baseBox, statusStyle[status]]} accessible={false}>
       {value &&
         (secret ? <SecretValue /> : <H6 accessible={false}>{value}</H6>)}
     </View>

--- a/src/components/otpInput/BoxedInput.tsx
+++ b/src/components/otpInput/BoxedInput.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useMemo } from "react";
-import { StyleSheet, View } from "react-native";
-import { IOColors } from "../../core";
+import { StyleSheet, View, ViewStyle } from "react-native";
+import { hexToRgba, IOColors, useIOTheme } from "../../core";
 import { H6, IOText } from "../typography";
 
 type Props = {
@@ -18,28 +18,13 @@ const styles = StyleSheet.create({
     height: 60,
     borderRadius: 8,
     borderCurve: "continuous"
-  },
-  defaultBox: {
-    borderWidth: 1,
-    borderColor: IOColors["grey-650"]
-  },
-  focusedBox: {
-    borderWidth: 2,
-    borderColor: IOColors["blueIO-500"]
-  },
-  errorBox: {
-    borderWidth: 1,
-    borderColor: IOColors["error-850"],
-    backgroundColor: IOColors["error-100"]
   }
 });
 
-// FIXME Replace this component with H3 once the legacy look is deprecated https://pagopa.atlassian.net/browse/IOPLT-153
 const SecretValue = () => (
   <IOText
     font="DMMono"
     weight="Semibold"
-    color="grey-850"
     size={22}
     lineHeight={33}
     accessible={false}
@@ -49,17 +34,33 @@ const SecretValue = () => (
 );
 
 export const BoxedInput = ({ status, value, secret }: Props) => {
-  const derivedStyle = useMemo(() => {
+  const theme = useIOTheme();
+
+  const derivedStyle: ViewStyle = useMemo(() => {
     switch (status) {
       case "error":
-        return styles.errorBox;
+        return {
+          borderWidth: 1,
+          borderColor: IOColors[theme["otpInputBorder-error"]],
+          backgroundColor: hexToRgba(
+            IOColors[theme["otpInputBorder-error"]],
+            0.15
+          )
+        };
       case "focus":
-        return styles.focusedBox;
+        return {
+          borderWidth: 2,
+          borderColor: IOColors[theme["interactiveElem-default"]]
+        };
       case "default":
       default:
-        return styles.defaultBox;
+        return {
+          borderWidth: 1,
+          borderColor: IOColors[theme["otpInputBorder-default"]]
+        };
     }
-  }, [status]);
+  }, [status, theme]);
+
   return (
     <View style={[styles.baseBox, derivedStyle]} accessible={false}>
       {value &&

--- a/src/components/otpInput/OTPInput.tsx
+++ b/src/components/otpInput/OTPInput.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { createRef, forwardRef, useEffect, useRef, useState } from "react";
 import {
   AccessibilityInfo,
   NativeSyntheticEvent,
@@ -9,6 +10,7 @@ import {
 } from "react-native";
 import Animated from "react-native-reanimated";
 import { IOStyles } from "../../core/IOStyles";
+import { useIOTheme } from "../../core";
 import { triggerHaptic } from "../../functions";
 import { useErrorShakeAnimation } from "../../utils/hooks/useErrorShakeAnimation";
 import { VSpacer } from "../spacer";
@@ -43,7 +45,7 @@ type Props = {
  * @param errorMessage - The error message to display
  * @returns
  */
-export const OTPInput = React.forwardRef<View, Props>(
+export const OTPInput = forwardRef<View, Props>(
   (
     {
       value,
@@ -61,14 +63,16 @@ export const OTPInput = React.forwardRef<View, Props>(
     },
     ref
   ) => {
-    const [hasFocus, setHasFocus] = React.useState(autoFocus);
-    const [hasError, setHasError] = React.useState(false);
+    const [hasFocus, setHasFocus] = useState(autoFocus);
+    const [hasError, setHasError] = useState(false);
+
+    const theme = useIOTheme();
 
     const { translate, animatedStyle, shakeAnimation } =
       useErrorShakeAnimation();
 
-    const inputRef = React.createRef<TextInput>();
-    const timerRef = React.useRef<NodeJS.Timeout>();
+    const inputRef = createRef<TextInput>();
+    const timerRef = useRef<NodeJS.Timeout>();
 
     const handleValidate = (val: string) => {
       if (!onValidate || val.length < length) {
@@ -92,7 +96,7 @@ export const OTPInput = React.forwardRef<View, Props>(
       }
     };
 
-    React.useEffect(() => () => clearTimeout(timerRef.current), []);
+    useEffect(() => () => clearTimeout(timerRef.current), []);
 
     const handleChange = (value: string) => {
       if (value.length > length) {
@@ -170,7 +174,7 @@ export const OTPInput = React.forwardRef<View, Props>(
         {hasError && errorMessage && (
           <BodySmall
             weight="Semibold"
-            color="error-850"
+            color={theme.errorText}
             style={{ textAlign: "center" }}
           >
             {errorMessage}

--- a/src/core/IOColors.ts
+++ b/src/core/IOColors.ts
@@ -232,6 +232,8 @@ const themeKeys = [
   "textInputLabel-default",
   "textInputValue-default",
   "textInputValue-disabled",
+  "otpInputBorder-default",
+  "otpInputBorder-error",
   // Selection (Radio, Checkbox, Switch)
   "switch-background-off",
   "switch-background-on",
@@ -302,6 +304,8 @@ export const IOThemeLight: IOTheme = {
   "textInputLabel-default": "grey-700",
   "textInputValue-default": "black",
   "textInputValue-disabled": "grey-850",
+  "otpInputBorder-default": "grey-650",
+  "otpInputBorder-error": "error-600",
   // Selection (Radio, Checkbox, Switch)
   "switch-background-off": "grey-700",
   "switch-background-on": "blueIO-500",
@@ -367,6 +371,8 @@ export const IOThemeDark: IOTheme = {
   "textInputLabel-default": "grey-450",
   "textInputValue-default": "white",
   "textInputValue-disabled": "grey-100",
+  "otpInputBorder-default": "grey-450",
+  "otpInputBorder-error": "error-400",
   // Selection (Radio, Checkbox, Switch)
   "switch-background-off": "grey-850",
   "switch-background-on": "blueIO-300",


### PR DESCRIPTION
## Short description
This PR adds dark mode support to `OTPInput`

## List of changes proposed in this pull request
- Add relative theme keys to the `IOTheme` object
- Slightly refactor `OTPInput` and `BoxedInput` to add theme keys

### Preview

https://github.com/user-attachments/assets/c76e67b4-0c29-4e79-b944-6e366d395b79


## How to test
Run the example app and go to the **OTPInput** page. Enable/disable dark mode for testing purposes.