### PR TITLE
fix: remove unresolved import `EXPERIMENTAL_DS_PARAM_KEY`

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,13 +1,9 @@
 import type { Preview } from "@storybook/react";
 import { IOThemeLight, IOThemeDark } from "../src/core";
 import { withEperimentalDs } from "../stories/utils";
-import { EXPERIMENTAL_DS_PARAM_KEY } from "../stories/addons/ExperimentalDsToggle";
 
 const preview: Preview = {
   decorators: [withEperimentalDs],
-  globals: {
-    [EXPERIMENTAL_DS_PARAM_KEY]: false
-  },
   parameters: {
     options: {
       storySort: {


### PR DESCRIPTION
## Short description
This pull request includes a change to the Storybook configuration to simplify the setup by removing unused global parameters.

## List of changes proposed in this pull request
- Removed the unused `EXPERIMENTAL_DS_PARAM_KEY` global parameter to clean up the configuration

## How to test
- Ensure that `yarn predeploy` command is not failing