### PR TITLE
fix: [IOPLT-1049] Restore previous `AvatarSearch` logic to avoid unexpected behavior in search results

### DIFF
--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -149,21 +149,6 @@ export const AvatarSearch = React.memo(
     const internalSpace = dimensionsMap.small.internalSpace;
     const innerRadius = borderRadius - internalSpace;
 
-    const indexValue = useRef<number>(0);
-    const [imageSource, setImageSource] = useState(
-      source === undefined ? undefined : addCacheTimestampToUri(source)
-    );
-
-    const onError = () => {
-      if (Array.isArray(source) && indexValue.current + 1 < source.length) {
-        // eslint-disable-next-line functional/immutable-data
-        indexValue.current = indexValue.current + 1;
-        setImageSource(addCacheTimestampToUri(source[indexValue.current]));
-        return;
-      }
-      setImageSource(undefined);
-    };
-
     return (
       <View
         accessibilityIgnoresInvertColors
@@ -183,10 +168,9 @@ export const AvatarSearch = React.memo(
         >
           <Image
             accessibilityIgnoresInvertColors
-            source={imageSource}
+            source={source}
             style={styles.avatarImage}
             defaultSource={defaultSource ?? avatarSearchPlaceholder}
-            onError={onError}
           />
         </View>
       </View>

--- a/src/components/avatar/__test__/__snapshots__/avatar.test.tsx.snap
+++ b/src/components/avatar/__test__/__snapshots__/avatar.test.tsx.snap
@@ -97,7 +97,6 @@ exports[`Test Avatar Components - Experimental Enabled AvatarSearch Snapshot 1`]
           "testUri": "../../../src/components/avatar/placeholder/avatar-placeholder.png",
         }
       }
-      onError={[Function]}
       source={
         {
           "uri": "",
@@ -212,7 +211,6 @@ exports[`Test Avatar Components AvatarSearch Snapshot 1`] = `
           "testUri": "../../../src/components/avatar/placeholder/avatar-placeholder.png",
         }
       }
-      onError={[Function]}
       source={
         {
           "uri": "",


### PR DESCRIPTION
## Short description
This PR restores previous `AvatarSearch` logic to avoid unexpected behavior in search results, due to `FlashList` optimisation techniques.

## List of changes proposed in this pull request
- Remove `useState` and `onError` function

## How to test
For testing purposes, please refer to the previous merged PR:
- https://github.com/pagopa/io-app-design-system/pull/447