### PR TITLE
chore: [IOPLT-1077] Add dark mode support for the `Stepper`

### DIFF
--- a/example/src/pages/Stepper.tsx
+++ b/example/src/pages/Stepper.tsx
@@ -1,32 +1,36 @@
+import {
+  ContentWrapper,
+  H1,
+  IOStyles,
+  IOVisualCostants,
+  Stepper,
+  VStack
+} from "@pagopa/io-app-design-system";
 import * as React from "react";
 import { View } from "react-native";
-import {
-  H1,
-  IOVisualCostants,
-  IOStyles,
-  VSpacer,
-  Stepper
-} from "@pagopa/io-app-design-system";
-import { Screen } from "../components/Screen";
+import { NoMarginScreen } from "../components/Screen";
 
 /**
  * This Screen is used to test components in isolation while developing.
  * @returns a screen with a flexed view where you can test components
  */
 export const StepperPage = () => (
-  <Screen>
+  <NoMarginScreen>
     <View
-      style={[IOStyles.flex, { paddingTop: IOVisualCostants.appMarginDefault }]}
+      style={[
+        IOStyles.flex,
+        { paddingTop: IOVisualCostants.appMarginDefault, gap: 24 }
+      ]}
     >
-      <H1>Stepper</H1>
-      <VSpacer size={24} />
-      <Stepper steps={8} currentStep={1} />
-      <VSpacer size={24} />
-      <Stepper steps={6} currentStep={4} />
-      <VSpacer size={24} />
-      <Stepper steps={4} currentStep={4} />
-      <VSpacer size={24} />
-      <Stepper steps={5} currentStep={1} />
+      <ContentWrapper>
+        <H1>Stepper</H1>
+      </ContentWrapper>
+      <VStack space={24}>
+        <Stepper steps={8} currentStep={1} />
+        <Stepper steps={6} currentStep={4} />
+        <Stepper steps={4} currentStep={4} />
+        <Stepper steps={5} currentStep={1} />
+      </VStack>
     </View>
-  </Screen>
+  </NoMarginScreen>
 );

--- a/src/components/stepper/Stepper.tsx
+++ b/src/components/stepper/Stepper.tsx
@@ -1,40 +1,47 @@
 import * as React from "react";
-import { Dimensions, LayoutChangeEvent, View } from "react-native";
-import { IOColors, IOSpacer, IOStyles, IOVisualCostants } from "../../core";
+import { ColorValue, View } from "react-native";
+import {
+  IOColors,
+  IOSpacer,
+  IOStyles,
+  IOVisualCostants,
+  useIOTheme
+} from "../../core";
 
 type StepperProps = {
   steps: number;
   currentStep: number;
 };
-const STEPPER_SPACE: IOSpacer = 4;
-
-const colorMap: Record<string, IOColors> = {
-  active: "blueIO-500"
-};
 
 export const Stepper = ({ steps, currentStep }: StepperProps) => {
-  const [stepWidth, setStepWidth] = React.useState(
-    Dimensions.get("window").width / steps
-  );
-  const onLayout = (e: LayoutChangeEvent) => {
-    setStepWidth(e.nativeEvent.layout.width / steps);
+  const theme = useIOTheme();
+
+  const STEPPER_SPACE: IOSpacer = 4;
+
+  const colorMap: Record<string, ColorValue> = {
+    default: IOColors[theme["stepper-default"]],
+    active: IOColors[theme["interactiveElem-default"]]
   };
 
   return (
     <View style={{ paddingHorizontal: IOVisualCostants.appMarginDefault }}>
       <View
-        onLayout={onLayout}
-        style={[IOStyles.flex, IOStyles.rowSpaceBetween]}
+        style={[
+          IOStyles.flex,
+          IOStyles.rowSpaceBetween,
+          { gap: STEPPER_SPACE }
+        ]}
       >
         {[...Array(steps)].map((_, i) => (
           <View
             key={i}
             style={{
               borderRadius: 2,
+              borderCurve: "continuous",
               borderBottomColor:
-                IOColors[i > currentStep - 1 ? "grey-200" : colorMap.active],
+                i > currentStep - 1 ? colorMap.default : colorMap.active,
               borderBottomWidth: 2,
-              width: stepWidth - STEPPER_SPACE
+              flex: 1
             }}
           />
         ))}

--- a/src/core/IOColors.ts
+++ b/src/core/IOColors.ts
@@ -227,6 +227,7 @@ const themeKeys = [
   // Design System related
   "cardBorder-default",
   "textInputBorder-default",
+  "stepper-default",
   "icon-default",
   "icon-decorative",
   // Inputs
@@ -254,7 +255,6 @@ const themeKeys = [
   "tab-item-foreground-default",
   "tab-item-foreground-selected",
   "tab-item-background-selected",
-
   // Status
   "errorIcon",
   "errorText",
@@ -300,6 +300,7 @@ export const IOThemeLight: IOTheme = {
   // Design System related
   "cardBorder-default": "grey-100",
   "icon-default": "grey-650",
+  "stepper-default": "grey-200",
   "icon-decorative": "grey-300",
   // Inputs
   "textInputBorder-default": "grey-200",
@@ -368,6 +369,7 @@ export const IOThemeDark: IOTheme = {
   "cardBorder-default": "grey-850",
   "icon-default": "grey-450",
   "icon-decorative": "grey-650",
+  "stepper-default": "grey-700",
   // Inputs
   "textInputBorder-default": "grey-850",
   "textInputLabel-default": "grey-450",


### PR DESCRIPTION
## Short description
This PR adds the dark mode support for the `Stepper` component.

## List of changes proposed in this pull request
- Refactor `Stepper` to add dark mode support
- Refactor `Stepper` to take advantage of the new `gap` property, instead of relying on `onLayout` computed values.

### Preview

https://github.com/user-attachments/assets/dd771c62-4171-405e-b673-78162ac7e515



## How to test
1. Launch the example app
2. Go to the **Stepper** and **Header Second Level (Stepper)** screens