### PR TITLE
fix: [IOCOM-242] Add accessible property to AnimatedMessageCheckbox

### DIFF
--- a/src/components/checkbox/AnimatedMessageCheckbox.tsx
+++ b/src/components/checkbox/AnimatedMessageCheckbox.tsx
@@ -19,7 +19,8 @@ type Props = {
   checked?: boolean;
 };
 
-type AnimatedMessageCheckbox = Props & Pick<PressableProps, "onPress">;
+type AnimatedMessageCheckbox = Props &
+  Pick<PressableProps, "accessible" | "onPress">;
 
 const internalSpacing: IOSpacingScale = 4;
 
@@ -45,6 +46,7 @@ const styles = StyleSheet.create({
  * list item (Select mode that enables related actions)
  */
 export const AnimatedMessageCheckbox = ({
+  accessible,
   checked,
   onPress
 }: AnimatedMessageCheckbox) => {
@@ -81,6 +83,7 @@ export const AnimatedMessageCheckbox = ({
 
   return (
     <Pressable
+      accessible={accessible}
       accessibilityRole="checkbox"
       accessibilityState={{ checked }}
       testID="AnimatedMessageCheckboxInput"


### PR DESCRIPTION
## Short description
This PR adds the 'accessible' property to AnimatedMessageCheckbox

## List of changes proposed in this pull request
- Such property is needed in the message list of IO App in order to prevent an external connected keyboard on Android to move focus on logos

## How to test
CI should succeed.
