### PR TITLE
feat: [SIW-2213] allow ListItemInfo to render without a label

### DIFF
--- a/example/src/pages/ListItem.tsx
+++ b/example/src/pages/ListItem.tsx
@@ -304,6 +304,7 @@ const renderListItemInfo = () => (
     <ComponentViewerBox name="ListItemInfo">
       <View>
         <ListItemInfo label="Label" value={"Value"} />
+        <ListItemInfo value={"Value without a label"} />
         <ListItemInfo
           label="Label"
           value="A looong looooong looooooooong looooooooooong title"
@@ -325,6 +326,19 @@ const renderListItemInfo = () => (
           icon="psp"
           label="Label"
           value="A looong looooong looooooooong looooooooooong title"
+          endElement={{
+            type: "iconButton",
+            componentProps: {
+              icon: "info",
+              accessibilityLabel: "info",
+              onPress: onButtonPress
+            }
+          }}
+        />
+
+        <ListItemInfo
+          icon="psp"
+          value="A looong looooong looooooooong looooooooooong title without a label"
           endElement={{
             type: "iconButton",
             componentProps: {

--- a/src/components/listitems/ListItemInfo.tsx
+++ b/src/components/listitems/ListItemInfo.tsx
@@ -53,8 +53,8 @@ type InteractiveProps = Pick<
 >;
 
 export type ListItemInfo = WithTestID<{
-  label: string;
   value: string | ReactNode;
+  label?: string;
   numberOfLines?: number;
   endElement?: EndElementProps;
   // Accessibility
@@ -68,8 +68,8 @@ export type ListItemInfo = WithTestID<{
 const PAYMENT_LOGO_SIZE: IOIconSizeScale = 24;
 
 export const ListItemInfo = ({
-  label,
   value,
+  label,
   numberOfLines = 2,
   reversed = false,
   icon,
@@ -95,7 +95,11 @@ export const ListItemInfo = ({
   );
 
   const listItemAccessibilityLabel = useMemo(
-    () => accessibilityLabel ?? `${label}; ${componentValueToAccessibility}`,
+    () =>
+      accessibilityLabel ??
+      (label
+        ? `${label}; ${componentValueToAccessibility}`
+        : componentValueToAccessibility),
     [label, componentValueToAccessibility, accessibilityLabel]
   );
 
@@ -105,9 +109,11 @@ export const ListItemInfo = ({
         accessible={Platform.OS === "ios"}
         style={{ flexDirection: reversed ? "column-reverse" : "column" }}
       >
-        <BodySmall weight="Regular" color={theme["textBody-tertiary"]}>
-          {label}
-        </BodySmall>
+        {label && (
+          <BodySmall weight="Regular" color={theme["textBody-tertiary"]}>
+            {label}
+          </BodySmall>
+        )}
         {typeof value === "string" ? (
           <H6 color={theme["textBody-default"]} numberOfLines={numberOfLines}>
             {value}


### PR DESCRIPTION
## Short description
This PR adds the possibility to render `ListItemInfo` without a label

## List of changes proposed in this pull request
- Label is now optional
- Fixed the accessibility label when the label is not available

## How to test
Navigate to the list item info example component and check that everything works as intended without regressions
