### PR TITLE
chore: [IOPLT-1103] Make `ContentWrapper` less restrictive in terms of accepted props

### DIFF
--- a/src/components/contentWrapper/ContentWrapper.tsx
+++ b/src/components/contentWrapper/ContentWrapper.tsx
@@ -1,13 +1,19 @@
-import React from "react";
-import { View } from "react-native";
+import React, { ReactNode } from "react";
+import { View, ViewProps, ViewStyle } from "react-native";
 import { WithTestID } from "src/utils/types";
 import type { IOAppMargin } from "../../core";
 import { IOVisualCostants } from "../../core/IOStyles";
 
-type IOContentWrapperProps = WithTestID<{
-  margin?: IOAppMargin;
-  children: React.ReactNode;
-}>;
+type IOContentWrapperProps = WithTestID<
+  Omit<ViewProps, "style"> & {
+    margin?: IOAppMargin;
+    children: ReactNode;
+    style?: Omit<
+      ViewStyle,
+      "paddingHorizontal" | "paddingLeft" | "paddingRight"
+    >;
+  }
+>;
 
 /**
 `ContentWrapper` is the main wrapper of the application. It automatically sets side margins,
@@ -16,14 +22,18 @@ depending on the size value
  */
 export const ContentWrapper = ({
   margin = IOVisualCostants.appMarginDefault,
+  style,
+  children,
   testID,
-  children
+  ...rest
 }: IOContentWrapperProps) => (
   <View
     testID={testID}
     style={{
-      paddingHorizontal: margin
+      paddingHorizontal: margin,
+      ...style
     }}
+    {...rest}
   >
     {children}
   </View>


### PR DESCRIPTION
## Short description
This PR makes `ContentWrapper` less restrictive in terms of accepted props. In fact, it now accepts all `View` props except for some styles already managed by the component itself.

## List of changes proposed in this pull request
- Update `ContentWrapper` with the new TS configuration

## How to test
N/A