### PR TITLE
fix: [IOPLT-1110] Fix glitchy behavior of `Alert` under certain conditions

### DIFF
--- a/src/components/alert/Alert.tsx
+++ b/src/components/alert/Alert.tsx
@@ -1,10 +1,8 @@
-import React, { forwardRef, useCallback, useState } from "react";
+import React, { forwardRef } from "react";
 import {
   ColorValue,
   GestureResponderEvent,
-  NativeSyntheticEvent,
   Pressable,
-  TextLayoutEventData,
   View,
   ViewStyle
 } from "react-native";
@@ -125,15 +123,6 @@ export const Alert = forwardRef<View, AlertType>(
       useIOFontDynamicScale();
     const { themeType } = useIOThemeContext();
 
-    const [isMultiline, setIsMultiline] = useState(false);
-
-    const onTextLayout = useCallback(
-      (event: NativeSyntheticEvent<TextLayoutEventData>) => {
-        setIsMultiline(event.nativeEvent.lines.length > 1);
-      },
-      []
-    );
-
     const paddingDefaultVariant: ViewStyle = {
       padding,
       borderRadius: IOAlertRadius * dynamicFontScale * spacingScaleMultiplier,
@@ -149,7 +138,7 @@ export const Alert = forwardRef<View, AlertType>(
       <HStack
         space={IOVisualCostants.iconMargin as IOSpacer}
         allowScaleSpacing
-        style={{ alignItems: isMultiline ? "flex-start" : "center" }}
+        style={{ alignItems: "center" }}
       >
         <Icon
           allowFontScaling
@@ -162,20 +151,17 @@ export const Alert = forwardRef<View, AlertType>(
       have to put these magic numbers after manual adjustments.
       Tested on both Android and iOS. */}
         <View
-          style={[
-            isMultiline && {
-              marginTop: -6 * dynamicFontScale,
-              marginBottom: -4 * dynamicFontScale
-            },
-            { flex: 1 }
-          ]}
+          style={{
+            marginTop: -4 * dynamicFontScale,
+            marginBottom: -4 * dynamicFontScale,
+            flex: 1
+          }}
         >
           <VStack space={8} allowScaleSpacing>
             <Body
               color={mapVariantStates[variant].foreground}
               weight={"Regular"}
               accessibilityRole="text"
-              onTextLayout={onTextLayout}
             >
               {content}
             </Body>


### PR DESCRIPTION
## Short description
This PR fixes a glitchy behavior of the `Alert` component, probably caused by the different rendering of margins and content alignment when the text was rendered on a single line or on multiple lines. The glitchy behavior occurred for a rare combination of scaled font size and a certain number of characters at the edge of the two scenarios.

## List of changes proposed in this pull request
- Remove the `multiLine` condition
- To avoid wrong vertical alignment of the text, make the icon vertically centred in all cases

## How to test
1. Go to the **Alert** page in the example app
2. Increase/decrease the font scale using Accessibility Inspector or your system settings