### PR TITLE
[SIW-2315,SIW-2316] Add `variant` prop to `FeatureInfo`

### DIFF
--- a/example/src/pages/Advice.tsx
+++ b/example/src/pages/Advice.tsx
@@ -96,28 +96,34 @@ const renderFeatureInfo = () => {
       <VSpacer size={16} />
       <ComponentViewerBox name="FeatureInfo · with Pictogram">
         <FeatureInfo
-          pictogramName="clock"
           body={
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ut labore et dolore magna aliqua. sed do eiusmod tempor ut labore et dolore magna aliqua"
           }
+          pictogramProps={{
+            name: "clock"
+          }}
         />
         <VSpacer size={24} />
         <FeatureInfo
-          pictogramName="manual"
           body={
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ut labore et dolore magna aliqua"
           }
+          pictogramProps={{
+            name: "manual"
+          }}
         />
         <VSpacer size={24} />
         <FeatureInfo
-          pictogramName="followMessage"
-          body={
-            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ut labore et dolore magna aliqua. sed do eiusmod tempor ut labore et dolore magna aliqua"
-          }
           action={{
             label: "Scopri di più",
             onPress: onLinkPress,
             accessibilityRole: "button"
+          }}
+          body={
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ut labore et dolore magna aliqua. sed do eiusmod tempor ut labore et dolore magna aliqua"
+          }
+          pictogramProps={{
+            name: "followMessage"
           }}
         />
       </ComponentViewerBox>

--- a/src/components/pictograms/Pictogram.tsx
+++ b/src/components/pictograms/Pictogram.tsx
@@ -189,7 +189,7 @@ export type IOPictograms = keyof typeof IOPictograms;
 
 export type IOPictogramSizeScale = 48 | 64 | 72 | 80 | 120 | 180;
 
-type IOPictogramsProps = {
+export type IOPictogramsProps = {
   name: IOPictograms;
   /* Not too happy about the API choice,
   but at least we have the same <StatusBar …>

--- a/src/components/typography/IOText.tsx
+++ b/src/components/typography/IOText.tsx
@@ -59,7 +59,7 @@ export type IOTextProps = IOTextBaseProps & IOTextExcludedProps;
  */
 export type TypographicStyleAsLinkProps =
   | {
-      color?: never;
+      color?: IOColors;
       asLink: true;
       onPress: (event: GestureResponderEvent) => void;
       accessibilityRole?: Extract<AccessibilityRole, "button" | "link">;

--- a/stories/featureInfo/FeatureInfo.stories.ts
+++ b/stories/featureInfo/FeatureInfo.stories.ts
@@ -16,7 +16,9 @@ const meta = {
   tags: ["autodocs"],
   decorators: [withMaxWitdth],
   args: {
-    pictogramName: "cie"
+    pictogramProps: {
+      name: "cie"
+    }
   }
 } satisfies Meta<typeof FeatureInfo>;
 


### PR DESCRIPTION
## Short description
This PR adds the `variant` prop to the `FeatureInfo` component.

## List of changes proposed in this pull request
- Added the `variant` prop to the FeatureInfo component
- Replaced the `pictogramName` with `pictogramProps` in the FeatureInfo component
- Updated `TypographicStyleAsLinkProps` to support custom color when the text is rendered as a link

## How to test
- Launch the example app
- Navigate to the **Advice & Banner** page
- Verify that the `FeatureInfo` component renders correctly
