### PR TITLE
chore: replace spread operator for `IOButton`

### DIFF
--- a/src/components/buttons/IOButton/IOButton.tsx
+++ b/src/components/buttons/IOButton/IOButton.tsx
@@ -276,7 +276,7 @@ export const IOButton = forwardRef<View, IOButtonProps>(
                 { textAlign },
                 disabled
                   ? { color: mapColorStates[color]?.foreground?.disabled }
-                  : { ...labelAnimatedStyle }
+                  : labelAnimatedStyle
               ]}
             >
               {label}


### PR DESCRIPTION
## Short description
This pull request includes a minor change to the `IOButton` component that simplifies the application of the `labelAnimatedStyle` by removing the unnecessary object spread operator.
This seems to solved the wrong button color for https://github.com/pagopa/io-app/pull/6888

## How to test
IOButton should work as before

## Preview

https://github.com/user-attachments/assets/51eba763-a8fb-4e6a-b7bb-a819ee6c0bbe


