### PR TITLE
fix: add button default color on disabled

### DIFF
--- a/src/components/buttons/IOButton/IOButton.tsx
+++ b/src/components/buttons/IOButton/IOButton.tsx
@@ -276,7 +276,8 @@ export const IOButton = forwardRef<View, IOButtonProps>(
                 { textAlign },
                 disabled
                   ? { color: mapColorStates[color]?.foreground?.disabled }
-                  : labelAnimatedStyle
+                  : { color: mapColorStates[color]?.foreground?.default },
+                !disabled && labelAnimatedStyle
               ]}
             >
               {label}

--- a/src/components/buttons/IOButton/__test__/__snapshots__/IOButton.test.tsx.snap
+++ b/src/components/buttons/IOButton/__test__/__snapshots__/IOButton.test.tsx.snap
@@ -120,6 +120,9 @@ exports[`Test Buttons Components IOButton Snapshot · Link variant 1`] = `
                 "textAlign": "auto",
               },
               {
+                "color": "#0B3EE3",
+              },
+              {
                 "color": undefined,
               },
             ],
@@ -249,6 +252,9 @@ exports[`Test Buttons Components IOButton Snapshot · Outline variant 1`] = `
                 "textAlign": "auto",
               },
               {
+                "color": "#0B3EE3",
+              },
+              {
                 "color": undefined,
               },
             ],
@@ -375,6 +381,9 @@ exports[`Test Buttons Components IOButton Snapshot · Solid variant 1`] = `
             [
               {
                 "textAlign": "auto",
+              },
+              {
+                "color": "#FFFFFF",
               },
               {
                 "color": undefined,


### PR DESCRIPTION
## Short description
This pull request includes a minor change to the `IOButton` component that adds a default foreground color when button is disabled

This seems to solved the wrong button color for https://github.com/pagopa/io-app/pull/6750#issuecomment-2879310599

## How to test
IOButton should work as before