### PR TITLE
chore: [IOPLT-1106] Set the default gap to zero in the `HStack` and `VStack` components

### DIFF
--- a/example/src/pages/Layout.tsx
+++ b/example/src/pages/Layout.tsx
@@ -163,6 +163,18 @@ export const Layout = () => {
             </HStack>
           </View>
         </ComponentViewerBox>
+
+        <ComponentViewerBox name="HStack, zero gap">
+          <View
+            style={{
+              backgroundColor: IOColors[theme["appBackground-secondary"]]
+            }}
+          >
+            <HStack style={{ padding: 16 }}>
+              <HStackBlocks />
+            </HStack>
+          </View>
+        </ComponentViewerBox>
       </ContentWrapper>
 
       <VSpacer size={24} />

--- a/src/components/stack/Stack.tsx
+++ b/src/components/stack/Stack.tsx
@@ -3,9 +3,9 @@ import { View, ViewProps, ViewStyle } from "react-native";
 import { IOSpacer } from "../../core";
 import { useIOFontDynamicScale } from "../../utils/accessibility";
 
-type AllowedStyleProps = Pick<
+type AllowedStyleProps = Exclude<
   ViewStyle,
-  "alignItems" | "flexShrink" | "flexGrow" | "flex" | "flexWrap" | "width"
+  "display" | "flexDirection" | "gap"
 >;
 
 type A11YRelatedProps = Pick<
@@ -14,7 +14,7 @@ type A11YRelatedProps = Pick<
 >;
 
 type Stack = PropsWithChildren<{
-  space?: IOSpacer;
+  space?: IOSpacer | 0;
   style?: AllowedStyleProps;
   allowScaleSpacing?: boolean;
 }> &
@@ -24,15 +24,13 @@ type BaseStack = Stack & {
   orientation: "vertical" | "horizontal";
 };
 
-const DEFAULT_SPACING_VALUE: IOSpacer = 16;
-
 /**
 Horizontal Stack component
 @param {IOSpacer} space
  */
 
 const Stack = ({
-  space = DEFAULT_SPACING_VALUE,
+  space = 0,
   style,
   orientation = "vertical",
   allowScaleSpacing,
@@ -47,9 +45,10 @@ const Stack = ({
       style={{
         display: "flex",
         flexDirection: orientation === "horizontal" ? "row" : "column",
-        gap: allowScaleSpacing
-          ? space * dynamicFontScale * spacingScaleMultiplier
-          : space,
+        gap:
+          allowScaleSpacing && space !== 0
+            ? space * dynamicFontScale * spacingScaleMultiplier
+            : space,
         ...style
       }}
     >


### PR DESCRIPTION
## Short description
Set the default gap to zero in the `HStack` and `VStack` components to make arranging UI elements horizontally easier, rather than inserting a `View` with `flex-direction: row` each time.

## List of changes proposed in this pull request
- Update `Stack` components
- Update `Layout` page to add an example

## How to test
Run the example app and check the **Layout** screen