### PR TITLE
fix: [IOPLT-1301] Fix persistent header background color after switch to light/dark mode

### DIFF
--- a/src/components/headers/HeaderSecondLevel.tsx
+++ b/src/components/headers/HeaderSecondLevel.tsx
@@ -301,7 +301,6 @@ export const HeaderSecondLevel = ({
       style={[
         { borderBottomWidth: 1, borderColor: borderColorTransparentState },
         ignoreSafeAreaMargin ? { borderColor: borderColorSolidState } : {},
-        !transparent ? { backgroundColor: headerBgColorSolidState } : {},
         headerWrapperAnimatedStyle
       ]}
     >


### PR DESCRIPTION
## Short description
This PR fixes an annoying visual bug that occurred when the user changed the theme (from light to dark mode and vice versa).

## List of changes proposed in this pull request
- Remove extra condition that conflicted with the `animatedStyle` set through `reanimated`

### Preview
The bug we fixed:

https://github.com/user-attachments/assets/6f285d72-9a5d-42dc-91cc-5e508fb85d40



## How to test
This bug is not replicable in the DS example app. Please test the change in the main `io-app`