### PR TITLE
fix: [IOPLT-1311] Removes pressable wrapper for markdown renderer integration

### DIFF
--- a/src/components/typography/Body.tsx
+++ b/src/components/typography/Body.tsx
@@ -28,6 +28,7 @@ export const Body = forwardRef<View, BodyStyleProps>(
       weight: customWeight,
       color: customColor,
       asLink,
+      avoidPressable,
       accessibilityRole = "link",
       textStyle: customTextStyle,
       onPress,
@@ -58,7 +59,7 @@ export const Body = forwardRef<View, BodyStyleProps>(
         : {})
     };
 
-    if (asLink) {
+    if (asLink && !avoidPressable) {
       return (
         <Pressable
           onPress={onPress}
@@ -71,7 +72,11 @@ export const Body = forwardRef<View, BodyStyleProps>(
     }
 
     return (
-      <IOText ref={ref} {...BodyProps}>
+      <IOText
+        ref={ref}
+        {...BodyProps}
+        onPress={asLink && avoidPressable ? onPress : undefined}
+      >
         {props.children}
       </IOText>
     );

--- a/src/components/typography/IOText.tsx
+++ b/src/components/typography/IOText.tsx
@@ -62,10 +62,11 @@ export type TypographicStyleAsLinkProps =
   | {
       color?: IOColors;
       asLink: true;
+      avoidPressable?: true;
       onPress: (event: GestureResponderEvent) => void;
       accessibilityRole?: Extract<AccessibilityRole, "button" | "link">;
     }
-  | { color?: IOColors; asLink?: false };
+  | { color?: IOColors; asLink?: false; avoidPressable?: false };
 
 /**
  * Decorate the function {@link makeFontStyleObject} with the additional color calculation.


### PR DESCRIPTION
## Short description
This PR removes the pressable wrapper on Body text component to solve a dynamic font sizing issue on the markdown render.

## List of changes proposed in this pull request
- adds the avoidPressable prop onto Typographic additional props

## How to test
Check the render of body text nothing should be changed except from the usage of the prop.
