### PR TITLE
refactor: [IOPLT-000] Adjust toast position when edge to edge enabled

### DIFF
--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -2,6 +2,7 @@ import { throttle } from "lodash";
 import React from "react";
 import {
   AccessibilityInfo,
+  Platform,
   SafeAreaView,
   StyleSheet,
   View
@@ -12,6 +13,7 @@ import Animated, {
   SlideInUp,
   SlideOutUp
 } from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { IOVisualCostants } from "../../core";
 import { triggerHaptic } from "../../functions";
 import { Dismissable } from "../templates";
@@ -116,10 +118,20 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
     [addToast, removeToast, removeAllToasts]
   );
 
+  const insets = useSafeAreaInsets();
+
   return (
     <ToastContext.Provider value={contextValue as ToastContext}>
       <InitializeToastRef />
-      <SafeAreaView style={styles.container} pointerEvents="box-none">
+      <SafeAreaView
+        style={[
+          styles.container,
+          {
+            paddingTop: Platform.OS === "android" ? insets.top : 0
+          }
+        ]}
+        pointerEvents="box-none"
+      >
         <View
           style={{ padding: IOVisualCostants.appMarginDefault }}
           pointerEvents="box-none"


### PR DESCRIPTION
## Short description
This pull request updates the `ToastProvider` component to improve safe area handling, especially on Android devices. The main change ensures that toast notifications respect the device's top safe area inset, preventing UI elements from overlapping with system UI

## List of changes proposed in this pull request
-  Updated the `SafeAreaView` in `ToastProvider` to apply a dynamic `paddingTop` based on the top inset when running on Android, improving visual consistency and usability

## How to test
With edge to edge enabled, ensure that `Toast` components are aligned correctly
## Preview

| Button mode | Gesture mode |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/f0b983e1-94ef-42ac-a08c-65773f795105"/> | <video src="https://github.com/user-attachments/assets/dd34e910-a651-45f6-978b-8d7c96757d64"/> | 

