### PR TITLE
feat: [IOBP-1987] Support badge as top element in `ListItemInfo`

### DIFF
--- a/example/src/pages/ListItem.tsx
+++ b/example/src/pages/ListItem.tsx
@@ -414,6 +414,17 @@ const renderListItemInfo = () => (
           }}
           value="A looong looooong looooooooong looooooooooong title"
         />
+        <ListItemInfo
+          topElement={{
+            type: "badge",
+            componentProps: {
+              text: "Success",
+              variant: "success"
+            }
+          }}
+          label="Title"
+          value="With both badge and label"
+        />
       </View>
     </ComponentViewerBox>
     <ComponentViewerBox name="ListItemInfo, onLongPress enabled">

--- a/src/components/listitems/ListItemInfo.tsx
+++ b/src/components/listitems/ListItemInfo.tsx
@@ -51,10 +51,12 @@ type InteractiveProps = Pick<
   "onLongPress" | "accessibilityActions" | "onAccessibilityAction"
 >;
 
-export type ListItemInfoBase = WithTestID<{
+export type ListItemInfo = WithTestID<{
   value: string | ReactNode;
+  label?: string;
   numberOfLines?: number;
   endElement?: EndElementProps;
+  topElement?: TopElementProps;
   // Accessibility
   accessibilityLabel?: string;
   accessibilityRole?: AccessibilityRole;
@@ -62,23 +64,6 @@ export type ListItemInfoBase = WithTestID<{
 }> &
   GraphicProps &
   InteractiveProps;
-
-type WithLabel = ListItemInfoBase & {
-  label: string;
-  topElement?: never;
-};
-
-type WithTopElement = ListItemInfoBase & {
-  topElement: TopElementProps;
-  label?: never;
-};
-
-type WithPlainListInfoBase = ListItemInfoBase & {
-  label?: undefined;
-  topElement?: undefined;
-};
-
-export type ListItemInfo = WithLabel | WithTopElement | WithPlainListInfoBase;
 
 const PAYMENT_LOGO_SIZE: IOIconSizeScale = 24;
 
@@ -126,14 +111,12 @@ export const ListItemInfo = ({
         style={{ flexDirection: reversed ? "column-reverse" : "column" }}
       >
         {topElement?.type === "badge" && (
-          <>
-            <View style={{ alignSelf: "flex-start" }}>
-              <Badge {...topElement.componentProps} />
-            </View>
-            <VSpacer size={8} />
-          </>
+          <View style={{ alignSelf: "flex-start" }}>
+            <Badge {...topElement.componentProps} />
+            <VSpacer size={4} />
+          </View>
         )}
-        {label && !topElement && (
+        {label && (
           <BodySmall weight="Regular" color={theme["textBody-tertiary"]}>
             {label}
           </BodySmall>


### PR DESCRIPTION
## Short description
This pull request introduces support for displaying a badge as a "top element" in the `ListItemInfo` component. The changes include updates to both the component's type definitions and its rendering logic, as well as new usage examples in the documentation.

## List of changes proposed in this pull request

* Added a new `topElement` prop to the `ListItemInfo` component, allowing a badge to be rendered above the value. Updated the component's rendering logic to display the badge when provided.
* Added new examples to the documentation demonstrating the use of `ListItemInfo` with a badge as the top element, including different badge variants.

## Preview
<img width="382" height="93" alt="image" src="https://github.com/user-attachments/assets/8c1e5ecb-4d46-447a-b807-243d041e3706" />

