### PR TITLE
fix: [SIW-3075] Remove pressable wrapper from `BodySmall` for markdown renderer integration

### DIFF
--- a/src/components/typography/BodySmall.tsx
+++ b/src/components/typography/BodySmall.tsx
@@ -25,6 +25,7 @@ export const BodySmall = forwardRef<View, BodySmallProps>(
       weight: customWeight,
       color: customColor,
       asLink,
+      avoidPressable,
       accessibilityRole = "link",
       textStyle: customTextStyle,
       onPress,
@@ -55,7 +56,7 @@ export const BodySmall = forwardRef<View, BodySmallProps>(
         : {})
     };
 
-    if (asLink) {
+    if (asLink && !avoidPressable) {
       return (
         <Pressable
           onPress={onPress}
@@ -68,7 +69,11 @@ export const BodySmall = forwardRef<View, BodySmallProps>(
     }
 
     return (
-      <IOText ref={ref} {...BodySmallProps}>
+      <IOText
+        ref={ref}
+        {...BodySmallProps}
+        onPress={asLink && avoidPressable ? onPress : undefined}
+      >
         {props.children}
       </IOText>
     );


### PR DESCRIPTION
## Short description
This PR complements #491 to fix the same issue in the `BodySmall` component.

## List of changes proposed in this pull request
-  Integrate the new `avoidPressable` prop in `BodySmall`

## How to test
Check the render of small body text: nothing should be changed except from the usage of the prop.