### PR TITLE
refactor: [IEL-000] Show counter limit prop

### DIFF
--- a/src/components/textInput/TextInputBase.tsx
+++ b/src/components/textInput/TextInputBase.tsx
@@ -55,6 +55,7 @@ type InputTextProps = WithTestID<{
   icon?: IOIcons;
   rightElement?: ReactNode;
   counterLimit?: number;
+  showCounterOnlyWhenLimitReached?: boolean;
   accessibilityAnnounceLimitReached?: string;
   bottomMessage?: string;
   bottomMessageColor?: IOColors;
@@ -123,6 +124,7 @@ type InputTextHelperRow = Pick<
   InputTextProps,
   | "value"
   | "counterLimit"
+  | "showCounterOnlyWhenLimitReached"
   | "bottomMessage"
   | "bottomMessageColor"
   | "inputType"
@@ -132,6 +134,7 @@ type InputTextHelperRow = Pick<
 const HelperRow = ({
   value,
   counterLimit,
+  showCounterOnlyWhenLimitReached,
   bottomMessage,
   bottomMessageColor,
   inputType,
@@ -153,13 +156,17 @@ const HelperRow = ({
   const bottomMessageColorValue =
     bottomMessageColor ?? bottomMessageColorDefault;
 
+  const shouldShowCounter =
+    !!counterLimit &&
+    (!showCounterOnlyWhenLimitReached || valueCount >= counterLimit);
+
   const helperRowStyle: ViewStyle = useMemo(() => {
-    if (counterLimit && bottomMessage) {
+    if (shouldShowCounter && bottomMessage) {
       return {
         justifyContent: "space-between"
       };
     }
-    if (counterLimit) {
+    if (shouldShowCounter) {
       return {
         justifyContent: "flex-end"
       };
@@ -170,7 +177,7 @@ const HelperRow = ({
       };
     }
     return {};
-  }, [counterLimit, bottomMessage]);
+  }, [shouldShowCounter, bottomMessage]);
 
   return (
     <View
@@ -193,7 +200,7 @@ const HelperRow = ({
           {bottomMessage}
         </BodySmall>
       )}
-      {counterLimit && (
+      {shouldShowCounter && (
         <BodySmall
           accessibilityLiveRegion="polite"
           weight="Regular"
@@ -218,6 +225,7 @@ export const TextInputBase = ({
   icon,
   rightElement,
   counterLimit,
+  showCounterOnlyWhenLimitReached,
   accessibilityAnnounceLimitReached,
   bottomMessage,
   bottomMessageColor,
@@ -556,6 +564,7 @@ export const TextInputBase = ({
           bottomMessage={bottomMessage}
           bottomMessageColor={bottomMessageColor}
           counterLimit={counterLimit}
+          showCounterOnlyWhenLimitReached={showCounterOnlyWhenLimitReached}
           inputType={inputType}
           textInputProps={textInputProps}
         />

--- a/src/components/textInput/TextInputValidation.tsx
+++ b/src/components/textInput/TextInputValidation.tsx
@@ -28,7 +28,8 @@ type TextInputValidationProps = Omit<
   ref?: Ref<TextInputValidationRefProps>;
   /**
    * If true, the character counter will only be displayed/announced when the counter limit is reached.
-   * If false or undefined, the character counter will be displayed/announced as soon as the user starts typing.
+   * If false or undefined, the character counter will be displayed/announced whenever the counter is enabled,
+   * including before the user starts typing (for example, `0 / limit`).
    */
   showCounterOnlyWhenLimitReached?: boolean;
   /**

--- a/src/components/textInput/TextInputValidation.tsx
+++ b/src/components/textInput/TextInputValidation.tsx
@@ -27,6 +27,11 @@ type TextInputValidationProps = Omit<
 > & {
   ref?: Ref<TextInputValidationRefProps>;
   /**
+   * If true, the character counter will only be displayed/announced when the counter limit is reached.
+   * If false or undefined, the character counter will be displayed/announced as soon as the user starts typing.
+   */
+  showCounterOnlyWhenLimitReached?: boolean;
+  /**
    * This function can return either a `boolean` or a `ValidationWithOptions` object.
    * If a `boolean` is returned and the field is not valid, the value of the errorMessage prop will be displayed/announced.
    * If a `ValidationWithOptions` object is returned and the field is not valid, the value displayed/announced will be the one contained within this object.


### PR DESCRIPTION
## Short description
This pull request introduces a new feature to the `TextInputBase` and `TextInputValidation` components that allows the character counter to be shown only when the character limit is reached. 

> [!IMPORTANT]
>  The goal of this development is to fix a bug where the `counterLimit` prop is initially set to `undefined` and later updated to a numeric value once a specific condition is met


## List of changes proposed in this pull request
- Added the `showCounterOnlyWhenLimitReached` prop to `InputTextProps` and `TextInputValidationProps`, allowing the character counter to be displayed only when the limit is reached
- Updated the `HelperRow` component and its logic to use the new prop, so the counter is only shown when appropriate

## How to test
In IO app point to this [development](https://github.com/pagopa/io-app/pull/8093) and ensure that is possible to edit input form when counter limit is reached

## Preview

https://github.com/user-attachments/assets/81b1bf92-1a0d-414f-b009-3507cbc4c197

